### PR TITLE
Switch Profile Inconsistent Network Profile Name Length Validation fix

### DIFF
--- a/plugins/modules/network_switch_profile_workflow_manager.py
+++ b/plugins/modules/network_switch_profile_workflow_manager.py
@@ -344,7 +344,7 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
         for each_profile in config:
             profile_name = each_profile.get("profile_name")
             if profile_name:
-                param_spec = dict(type="str", length_max=200)
+                param_spec = dict(type="str", length_max=255)
                 validate_str(profile_name, param_spec, "profile_name", errormsg)
             else:
                 errormsg.append("profile_name: Profile Name is missing in playbook.")


### PR DESCRIPTION
## Description

CSCwo49054 - Inconsistent Network Profile Name Length Validation

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

