### PR TITLE
Switch profie -Error message clarity changed the exception message

### DIFF
--- a/plugins/module_utils/network_profiles.py
+++ b/plugins/module_utils/network_profiles.py
@@ -134,9 +134,9 @@ class NetworkProfileFunctions(DnacBase):
                 return child_site_response
 
         except Exception as e:
-            self.log("An error occurred during get child sites: {0}".format(str(e)), "ERROR")
-            self.msg = 'Error retrieving child site(s): No child site(s) found for {0}'.format(
+            self.msg = 'Error retrieving child site(s): No child site(s) found for {0}. '.format(
                 site_name_hierarchy)
+            self.log(self.msg + str(e), "ERROR")
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -202,8 +202,8 @@ class NetworkProfileFunctions(DnacBase):
                 return None
 
         except Exception as e:
-            self.log("An error occurred during get templates details: {0}".format(str(e)), "ERROR")
             self.msg = 'Error on retrieving templates: No template list received'
+            self.log(self.msg + str(e), "ERROR")
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -246,9 +246,9 @@ class NetworkProfileFunctions(DnacBase):
             return profiles
 
         except Exception as e:
-            self.log("An error occurred during get network profile: {0}".format(str(e)), "ERROR")
-            self.msg = "Error on retrieving {0} profile list: Unable to get the profile list".format(
+            self.msg = "Error on retrieving {0} profile list: Unable to get the profile list. ".format(
                 profile_type)
+            self.log(self.msg + str(e), "ERROR")
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -288,10 +288,9 @@ class NetworkProfileFunctions(DnacBase):
             return templates
 
         except Exception as e:
-            self.log("An error occurred during retrieve cli templates for profile: {0}".
-                     format(str(e)), "ERROR")
             self.msg = "Error on retrieving templates for profile: Unable to retrieve the templates " +\
                 "for profile '{0}'".format(profile_id)
+            self.log(self.msg + str(e), "ERROR")
             return None
 
     def attach_networkprofile_cli_template(self, profile_name, profile_id, template_name,
@@ -327,10 +326,9 @@ class NetworkProfileFunctions(DnacBase):
                                                   function_name, profile_payload)
 
         except Exception as e:
-            self.log("Failed to attach profile '{0}' to CLI template '{1}': {2}".
-                     format(profile_name, template_name, str(e)), "ERROR")
             error_msg = "Error attaching template(s): Unable to attach profile '{0}' to CLI template '{1}'.".format(
                 profile_name, template_name)
+            self.log(error_msg + str(e), "ERROR")
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -366,8 +364,9 @@ class NetworkProfileFunctions(DnacBase):
                                                   function_name, profile_payload)
 
         except Exception as e:
-            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{1}': {2}".format(
-                profile_name, template_name, str(e))
+            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{1}'. ".format(
+                profile_name, template_name)
+            self.log(error_msg + str(e), "ERROR")
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -544,8 +543,8 @@ class NetworkProfileFunctions(DnacBase):
             return None
 
         except Exception as e:
-            self.msg = 'An error occurred during get task details: {0}'.format(str(e))
-            self.log(self.msg, "ERROR")
+            self.msg = 'An error occurred during get task details. '
+            self.log(self.msg + str(e), "ERROR")
             self.fail_and_exit(self.msg)
 
     def value_exists(self, data, target_key, target_value):

--- a/plugins/module_utils/network_profiles.py
+++ b/plugins/module_utils/network_profiles.py
@@ -401,11 +401,9 @@ class NetworkProfileFunctions(DnacBase):
                 params
             )
         except Exception as e:
-            error_msg = "Failed to assign the site(s) '{0}' to the profile '{1}' : {2}".format(
-                site_name, profile_name, str(e))
-            self.log(error_msg, "ERROR")
-            error_msg = "Failed to assign site(s) '{0}' to profile '{1}'.".format(
+            error_msg = "Failed to assign the site(s) '{0}' to the profile '{1}'".format(
                 site_name, profile_name)
+            self.log(error_msg + str(e), "ERROR")
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -439,11 +437,9 @@ class NetworkProfileFunctions(DnacBase):
                 param
             )
         except Exception as e:
-            error_msg = "Failed to unassign the site(s) '{0}' from the profile '{1}' : {2}".format(
-                site_name, profile_name, str(e))
-            self.log(error_msg, "ERROR")
-            error_msg = "Error on unassign site(s): Failed to unassign the site(s) '{0}' from the profile '{1}'".format(
+            error_msg = "Failed to unassign site(s) '{0}' from profile '{1}'. ".format(
                 site_name, profile_name)
+            self.log(error_msg + str(e), "ERROR")
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -474,10 +470,8 @@ class NetworkProfileFunctions(DnacBase):
                 "site_design", "deletes_a_network_profile_for_sites_v1", param
             )
         except Exception as e:
-            error_msg = "Failed to delete the network profile: '{0}' {1}".format(profile_name, str(e))
-            self.log(error_msg, "ERROR")
-            error_msg = "Error on profile deletion: Unable to delete the network profile '{0}'".format(
-                profile_name)
+            error_msg = "Failed to delete network profile '{0}'. ".format(profile_name)
+            self.log(error_msg + str(e), "ERROR")
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 

--- a/plugins/module_utils/network_profiles.py
+++ b/plugins/module_utils/network_profiles.py
@@ -134,9 +134,8 @@ class NetworkProfileFunctions(DnacBase):
                 return child_site_response
 
         except Exception as e:
-            self.msg = 'An error occurred during get child sites: {0}'.format(str(e))
-            self.log(self.msg, "ERROR")
-            self.msg = 'Error on retriving child site(s): No child site(s) found for {0}'.format(
+            self.log("An error occurred during get child sites: {0}".format(str(e)), "ERROR")
+            self.msg = 'Error retrieving child site(s): No child site(s) found for {0}'.format(
                 site_name_hierarchy)
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
@@ -203,9 +202,8 @@ class NetworkProfileFunctions(DnacBase):
                 return None
 
         except Exception as e:
-            self.msg = 'An error occurred during get templates details: {0}'.format(str(e))
-            self.log(self.msg, "ERROR")
-            self.msg = 'Error on retriving templates: No template list received'
+            self.log("An error occurred during get templates details: {0}".format(str(e)), "ERROR")
+            self.msg = 'Error on retrieving templates: No template list received'
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -248,9 +246,8 @@ class NetworkProfileFunctions(DnacBase):
             return profiles
 
         except Exception as e:
-            self.msg = 'An error occurred during get network profile: {0}'.format(str(e))
-            self.log(self.msg, "ERROR")
-            self.msg = "Error on retrive {0} profile list: Unable to get the profile list".format(
+            self.log("An error occurred during get network profile: {0}".format(str(e)), "ERROR")
+            self.msg = "Error on retrieving {0} profile list: Unable to get the profile list".format(
                 profile_type)
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
@@ -291,10 +288,9 @@ class NetworkProfileFunctions(DnacBase):
             return templates
 
         except Exception as e:
-            self.msg = "An error occurred during retrieve cli templates " +\
-                "for profile: {0}".format(str(e))
-            self.log(self.msg, "ERROR")
-            self.msg = "Error on retrive templates for profile: Unable to retrive the templates " +\
+            self.log("An error occurred during retrieve cli templates for profile: {0}".
+                     format(str(e)), "ERROR")
+            self.msg = "Error on retrieving templates for profile: Unable to retrieve the templates " +\
                 "for profile '{0}'".format(profile_id)
             return None
 
@@ -331,10 +327,9 @@ class NetworkProfileFunctions(DnacBase):
                                                   function_name, profile_payload)
 
         except Exception as e:
-            error_msg = "Failed to attach profile '{0}' to CLI template '{1}': {2}".format(
-                profile_name, template_name, str(e))
-            self.log(error_msg, "ERROR")
-            error_msg = "Error on attaching template(s): Unable to attach profile '{0}' to CLI template '{1}'".format(
+            self.log("Failed to attach profile '{0}' to CLI template '{1}': {2}".
+                     format(profile_name, template_name, str(e)), "ERROR")
+            error_msg = "Error attaching template(s): Unable to attach profile '{0}' to CLI template '{1}'.".format(
                 profile_name, template_name)
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
@@ -371,11 +366,8 @@ class NetworkProfileFunctions(DnacBase):
                                                   function_name, profile_payload)
 
         except Exception as e:
-            error_msg = "Failed to detach network profile '{0}' (ID: {1}) from CLI template '{2}' (ID: {3}): {4}".format(
-                profile_name, profile_id, template_name, template_id, str(e))
-            self.log(error_msg, "ERROR")
-            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{1}'".format(
-                profile_name, template_name)
+            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{1}': {2}".format(
+                profile_name, template_name, str(e))
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -412,7 +404,7 @@ class NetworkProfileFunctions(DnacBase):
             error_msg = "Failed to assign the site(s) '{0}' to the profile '{1}' : {2}".format(
                 site_name, profile_name, str(e))
             self.log(error_msg, "ERROR")
-            error_msg = "Error on assign site(s): Unable to assign the site(s) '{0}' to the profile '{1}'".format(
+            error_msg = "Failed to assign site(s) '{0}' to profile '{1}'.".format(
                 site_name, profile_name)
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None

--- a/plugins/module_utils/network_profiles.py
+++ b/plugins/module_utils/network_profiles.py
@@ -136,6 +136,8 @@ class NetworkProfileFunctions(DnacBase):
         except Exception as e:
             self.msg = 'An error occurred during get child sites: {0}'.format(str(e))
             self.log(self.msg, "ERROR")
+            self.msg = 'Error on retriving child site(s): No child site(s) found for {0}'.format(
+                site_name_hierarchy)
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -203,6 +205,7 @@ class NetworkProfileFunctions(DnacBase):
         except Exception as e:
             self.msg = 'An error occurred during get templates details: {0}'.format(str(e))
             self.log(self.msg, "ERROR")
+            self.msg = 'Error on retriving templates: No template list received'
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -247,6 +250,8 @@ class NetworkProfileFunctions(DnacBase):
         except Exception as e:
             self.msg = 'An error occurred during get network profile: {0}'.format(str(e))
             self.log(self.msg, "ERROR")
+            self.msg = "Error on retrive {0} profile list: Unable to get the profile list".format(
+                profile_type)
             self.set_operation_result("failed", False, self.msg, "ERROR")
             return None
 
@@ -289,6 +294,8 @@ class NetworkProfileFunctions(DnacBase):
             self.msg = "An error occurred during retrieve cli templates " +\
                 "for profile: {0}".format(str(e))
             self.log(self.msg, "ERROR")
+            self.msg = "Error on retrive templates for profile: Unable to retrive the templates " +\
+                "for profile '{0}'".format(profile_id)
             return None
 
     def attach_networkprofile_cli_template(self, profile_name, profile_id, template_name,
@@ -327,6 +334,8 @@ class NetworkProfileFunctions(DnacBase):
             error_msg = "Failed to attach profile '{0}' to CLI template '{1}': {2}".format(
                 profile_name, template_name, str(e))
             self.log(error_msg, "ERROR")
+            error_msg = "Error on attaching template(s): Unable to attach profile '{0}' to CLI template '{1}'".format(
+                profile_name, template_name)
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -365,6 +374,8 @@ class NetworkProfileFunctions(DnacBase):
             error_msg = "Failed to detach network profile '{0}' (ID: {1}) from CLI template '{2}' (ID: {3}): {4}".format(
                 profile_name, profile_id, template_name, template_id, str(e))
             self.log(error_msg, "ERROR")
+            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{2}'".format(
+                profile_name, template_name)
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None
 
@@ -392,10 +403,19 @@ class NetworkProfileFunctions(DnacBase):
             "id": site_id
         }
 
-        return self.execute_process_task_data(
-            "site_design", "assign_a_network_profile_for_sites_to_the_given_site_v1",
-            params
-        )
+        try:
+            return self.execute_process_task_data(
+                "site_design", "assign_a_network_profile_for_sites_to_the_given_site_v1",
+                params
+            )
+        except Exception as e:
+            error_msg = "Failed to assign the site(s) '{0}' to the profile '{1}' : {2}".format(
+                site_name, profile_name, str(e))
+            self.log(error_msg, "ERROR")
+            error_msg = "Error on assign site(s): Unable to assign the site(s) '{0}' to the profile '{1}'".format(
+                site_name, profile_name)
+            self.set_operation_result("failed", False, error_msg, "ERROR")
+            return None
 
     def unassign_site_to_network_profile(self, profile_name, profile_id, site_name, site_id):
         """
@@ -421,10 +441,19 @@ class NetworkProfileFunctions(DnacBase):
         self.log("Unassigning site {0}: {1} from network profile {2}: {3}.".
                  format(site_name, site_id, profile_name, profile_id), "INFO")
 
-        return self.execute_process_task_data(
-            "site_design", "unassigns_a_network_profile_for_sites_from_multiple_sites_v1",
-            param
-        )
+        try:
+            return self.execute_process_task_data(
+                "site_design", "unassigns_a_network_profile_for_sites_from_multiple_sites_v1",
+                param
+            )
+        except Exception as e:
+            error_msg = "Failed to unassign the site(s) '{0}' from the profile '{1}' : {2}".format(
+                site_name, profile_name, str(e))
+            self.log(error_msg, "ERROR")
+            error_msg = "Error on unassign site(s): Failed to unassign the site(s) '{0}' from the profile '{1}'".format(
+                site_name, profile_name)
+            self.set_operation_result("failed", False, error_msg, "ERROR")
+            return None
 
     def delete_network_profiles(self, profile_name, profile_id):
         """
@@ -448,9 +477,17 @@ class NetworkProfileFunctions(DnacBase):
             "id": profile_id,
         }
 
-        return self.execute_process_task_data(
-            "site_design", "deletes_a_network_profile_for_sites_v1", param
-        )
+        try:
+            return self.execute_process_task_data(
+                "site_design", "deletes_a_network_profile_for_sites_v1", param
+            )
+        except Exception as e:
+            error_msg = "Failed to delete the network profile: '{0}' {1}".format(profile_name, str(e))
+            self.log(error_msg, "ERROR")
+            error_msg = "Error on profile deletion: Unable to delete the network profile '{0}'".format(
+                profile_name)
+            self.set_operation_result("failed", False, error_msg, "ERROR")
+            return None
 
     def execute_process_task_data(self, profile_family, profile_function_name,
                                   payload_data, task_id=None):

--- a/plugins/module_utils/network_profiles.py
+++ b/plugins/module_utils/network_profiles.py
@@ -374,7 +374,7 @@ class NetworkProfileFunctions(DnacBase):
             error_msg = "Failed to detach network profile '{0}' (ID: {1}) from CLI template '{2}' (ID: {3}): {4}".format(
                 profile_name, profile_id, template_name, template_id, str(e))
             self.log(error_msg, "ERROR")
-            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{2}'".format(
+            error_msg = "Error on detach template(s): Unable to detach network profile '{0}' from CLI template(s) '{1}'".format(
                 profile_name, template_name)
             self.set_operation_result("failed", False, error_msg, "ERROR")
             return None

--- a/plugins/modules/network_profile_switching_workflow_manager.py
+++ b/plugins/modules/network_profile_switching_workflow_manager.py
@@ -613,11 +613,9 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                 return False, matched_site_ids
 
             except Exception as e:
-                msg = 'An error occurred during site comparison {0}. '.format(
-                    each_config)
+                msg = "Error on site name comparison: Unable to compare config {0} with existing {1}".format(
+                    each_config, data_list)
                 self.log(msg + str(e), "ERROR")
-                msg = "Error on site name comparison: Unable to compare config {0} with existing {0}".format(
-                    config_type)
                 self.fail_and_exit(msg)
 
         else:
@@ -781,10 +779,9 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                                  format(response.status_code, str(response.text)), "ERROR")
 
                 except Exception as e:
-                    msg = 'An error occurred during create Switch profile: {0}'.format(str(e))
-                    self.log(msg, "ERROR")
-                    msg = "Error on creating Network Profile: Unable to get the success response creating profile '{0}'".format(
+                    msg = "Error on creating Network Profile: Unable to get the success response creating profile '{0}'. ".format(
                         each_config["profile_name"])
+                    self.log(msg + str(e), "ERROR")
                     self.fail_and_exit(msg)
 
         self.log("No matching switch profile found. Skipping profile creation/update.", "INFO")

--- a/plugins/modules/network_profile_switching_workflow_manager.py
+++ b/plugins/modules/network_profile_switching_workflow_manager.py
@@ -104,7 +104,7 @@ EXAMPLES = r"""
 - hosts: dnac_servers
   vars_files:
     - credentials.yml
-  gather_facts: no
+  gather_facts: false
   connection: local
   tasks:
     - name: Create network profile for switch
@@ -152,14 +152,14 @@ EXAMPLES = r"""
         config:
           - profile_name: "Enterprise_Switching_Profile"
             onboarding_templates:
-            - "Access_Switch_Onboarding"
-            - "Enterprise_Security_Template"
+              - "Access_Switch_Onboarding"
+              - "Enterprise_Security_Template"
             day_n_templates:
-            - "Periodic_Config_Audit"
+              - "Periodic_Config_Audit"
             site_names:
-            - "Global/India/Chennai/Main_Office"
-            - "Global/India/Madurai/Branch_Office"
-            - "Global/USA/San Francisco/Regional_HQ"
+              - "Global/India/Chennai/Main_Office"
+              - "Global/India/Madurai/Branch_Office"
+              - "Global/USA/San Francisco/Regional_HQ"
 
     - name: Delete switching profile for devices from specified sites
       cisco.dnac.network_profile_switching_workflow_manager:
@@ -613,9 +613,9 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                 return False, matched_site_ids
 
             except Exception as e:
-                msg = 'An error occurred during site comparison {0}: {1}'.format(
-                    each_config, str(e))
-                self.log(msg, "ERROR")
+                msg = 'An error occurred during site comparison {0}. '.format(
+                    each_config)
+                self.log(msg + str(e), "ERROR")
                 msg = "Error on site name comparison: Unable to compare config {0} with existing {0}".format(
                     config_type)
                 self.fail_and_exit(msg)
@@ -659,10 +659,9 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
             return site_list
 
         except Exception as e:
-            msg = 'An error occurred during retrieve sites for profile: {0}'.format(str(e))
-            self.log(msg, "ERROR")
             msg = "Error on retrive sites for profile: Unable to retrive the site list for the profile '{0}'".format(
                 profile_name)
+            self.log(msg + str(e), "ERROR")
             self.set_operation_result("failed", False, msg, "INFO")
             return None
 

--- a/plugins/modules/network_profile_switching_workflow_manager.py
+++ b/plugins/modules/network_profile_switching_workflow_manager.py
@@ -580,9 +580,8 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                 return False, un_match_template
 
             except Exception as e:
-                msg = 'An error occurred during template comparision: {0}'.format(str(e))
-                self.log(msg, "ERROR")
-                msg = "Error on template comparision: Unable to compare config {0} with exising {0}".format(
+                self.log('An error occurred during template comparison: {0}'.format(str(e)), "ERROR")
+                msg = "Error comparing template: Unable to compare config {0} with existing config '{0}'".format(
                     config_type)
                 self.fail_and_exit(msg)
 
@@ -614,10 +613,10 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                 return False, matched_site_ids
 
             except Exception as e:
-                msg = 'An error occurred during site comparision {0}: {1}'.format(
+                msg = 'An error occurred during site comparison {0}: {1}'.format(
                     each_config, str(e))
                 self.log(msg, "ERROR")
-                msg = "Error on site name comparision: Unable to compare config {0} with existing {0}".format(
+                msg = "Error on site name comparison: Unable to compare config {0} with existing {0}".format(
                     config_type)
                 self.fail_and_exit(msg)
 
@@ -687,6 +686,11 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
         """
         self.log("Starting switch profile creation/update process.", "INFO")
         host_name = self.params["dnac_host"]
+        if not host_name:
+            msg = "Cisco Catalyst Center host information is missing."
+            self.log(msg, "ERROR")
+            self.fail_and_exit(msg)
+
         # Direct API call as SDK is not available yet
         dnac_url = "https://{0}".format(str(host_name))
 

--- a/plugins/modules/network_profile_switching_workflow_manager.py
+++ b/plugins/modules/network_profile_switching_workflow_manager.py
@@ -580,9 +580,9 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
                 return False, un_match_template
 
             except Exception as e:
-                self.log('An error occurred during template comparison: {0}'.format(str(e)), "ERROR")
-                msg = "Error comparing template: Unable to compare config {0} with existing config '{0}'".format(
-                    config_type)
+                msg = "Error comparing template: Unable to compare config '{0}' with existing config '{1}'".format(
+                    each_config, data_list)
+                self.log(msg + str(e), "ERROR")
                 self.fail_and_exit(msg)
 
         elif config_type == "sites":


### PR DESCRIPTION
## Description
CSCwo49064 - [IaC3] [Network Profile] Improve Error Message Clarity for Switch Network Profile Creation Failures

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

