### PR TITLE
Assurance Issue name lenth removed

### DIFF
--- a/plugins/modules/assurance_issue_workflow_manager.py
+++ b/plugins/modules/assurance_issue_workflow_manager.py
@@ -1003,7 +1003,7 @@ class AssuranceSettings(DnacBase):
             for each_issue in assurance_issue:
                 issue_name = each_issue.get("issue_name")
                 if issue_name:
-                    param_spec = dict(type="str", length_max=100)
+                    param_spec = dict(type="str")
                     validate_str(issue_name, param_spec, "issue_name", errormsg)
                 else:
                     errormsg.append("issue_name: Issue Name is missing in playbook.")


### PR DESCRIPTION
## Description
CSCwo81395 - Playbook Fails When issue_name Exceeds 100 Characters, While UI Handles It Gracefully

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

