### PR TITLE
Wireless profile OB template None type error fixed

### DIFF
--- a/plugins/modules/network_profile_wireless_workflow_manager.py
+++ b/plugins/modules/network_profile_wireless_workflow_manager.py
@@ -444,7 +444,7 @@ class NetworkWirelessProfile(NetworkProfileFunctions):
                     break
 
         ssid_list = config.get("ssid_details")
-        if ssid_list:
+        if ssid_list and isinstance(ssid_list, list):
             self.validate_ssid_info(ssid_list, config, errormsg)
 
         onboarding_templates = config.get("onboarding_templates")

--- a/plugins/modules/network_profile_wireless_workflow_manager.py
+++ b/plugins/modules/network_profile_wireless_workflow_manager.py
@@ -459,7 +459,7 @@ class NetworkWirelessProfile(NetworkProfileFunctions):
                         duplicate_template))
                     break
 
-                if template_name in day_n_templates:
+                if day_n_templates and template_name in day_n_templates:
                     errormsg.append("Onboarding_templates: Duplicate template " +
                                     "'{0}' found in day_n_templates".format(template_name))
                     break


### PR DESCRIPTION
## Description
CSCwo82813 - [IaC3][Wireless Profile] TypeError: argument of type 'NoneType' is not itterable

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

