### PR TITLE
Switch Profile OB template need not allow

### DIFF
--- a/plugins/modules/network_profile_switching_workflow_manager.py
+++ b/plugins/modules/network_profile_switching_workflow_manager.py
@@ -353,6 +353,8 @@ class NetworkSwitchProfile(NetworkProfileFunctions):
             onboarding_template_name = each_profile.get("onboarding_templates")
             day_n_template_name = each_profile.get("day_n_templates")
             if onboarding_template_name:
+                errormsg.append("onboarding_templates: Onboarding templates are currently unavailable "
+                                "due to SDK/API constraints. Please use the PNP onboarding template instead.")
                 for template in onboarding_template_name:
                     param_spec = dict(type="str", length_max=200)
                     validate_str(template, param_spec, "onboarding_templates", errormsg)

--- a/tests/unit/modules/dnac/fixtures/network_profile_switching_workflow_manager.json
+++ b/tests/unit/modules/dnac/fixtures/network_profile_switching_workflow_manager.json
@@ -2,7 +2,6 @@
     "playbook_config_creation": [
         {
           "profile_name": "sd_sw_1",
-          "onboarding_templates": ["Ansible_PNP_Switch"],
           "day_n_templates": ["Template Provisioning To Device"],
           "site_names": [
             "Global/Chennai/LTTS/FLOOR11",

--- a/tests/unit/modules/dnac/test_network_profile_switching_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_network_profile_switching_workflow_manager.py
@@ -56,7 +56,6 @@ class TestDnacSwitchWorkflow(TestDnacModule):
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_network_profile_not_exist"),
                 self.test_data.get("get_templates_details"),
-                self.test_data.get("get_templates_details"),
                 self.test_data.get("get_site_response1"),
                 self.test_data.get("get_site_response1"),
                 self.test_data.get("get_site_response2"),
@@ -64,7 +63,6 @@ class TestDnacSwitchWorkflow(TestDnacModule):
         elif "deletion_switch_fail" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_network_profile"),
-                self.test_data.get("get_templates_details"),
                 self.test_data.get("get_templates_details"),
                 self.test_data.get("get_site_response1"),
                 self.test_data.get("get_site_response1"),
@@ -126,5 +124,5 @@ class TestDnacSwitchWorkflow(TestDnacModule):
             result.get('msg'),
             "Unable to delete the profile '[{'profile_name': 'sd_sw_1', 'site_names': " +
             "['Global/Chennai/LTTS/FLOOR11', 'Global/Madurai/LTTS/FLOOR1'], 'onboarding_templates': " +
-            "['Ansible_PNP_Switch'], 'day_n_templates': ['Template Provisioning To Device']}]'."
+            "None, 'day_n_templates': ['Template Provisioning To Device']}]'."
         )


### PR DESCRIPTION
## Description
Switch Profile onboarding template, if customer given need show the message. updated

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

