### PR TITLE
Bug fix: SDA Fabric Multicast: Added support for creating multicast for multiple fabric sites.

### DIFF
--- a/plugins/modules/sda_fabric_multicast_workflow_manager.py
+++ b/plugins/modules/sda_fabric_multicast_workflow_manager.py
@@ -3305,7 +3305,7 @@ class FabricMulticast(DnacBase):
             to_create_multicast_grouped_by_fabric_id = self.group_payload_by_fabric_id(
                 to_create_multicast)
             self.log(
-                f"Total fabricId groups to be created: {len(to_create_multicast_grouped_by_fabric_id)}",
+                f"Total fabric ID groups to be created: {len(to_create_multicast_grouped_by_fabric_id)}",
                 "INFO",
             )
             for fabric_id, to_create_multicast_configs in to_create_multicast_grouped_by_fabric_id.items():
@@ -3337,7 +3337,7 @@ class FabricMulticast(DnacBase):
             to_update_multicast_grouped_by_fabric_id = self.group_payload_by_fabric_id(
                 to_update)
             self.log(
-                f"Total fabricId groups to be updated: {len(to_update_multicast_grouped_by_fabric_id)}",
+                f"Total fabric ID groups to be updated: {len(to_update_multicast_grouped_by_fabric_id)}",
                 "INFO",
             )
             for fabric_id, to_update_multicast_configs in to_update_multicast_grouped_by_fabric_id.items():
@@ -3370,7 +3370,7 @@ class FabricMulticast(DnacBase):
             items specific to each fabric site in Cisco Catalyst Center.
             If the input is not a list of dictionaries or is empty, it returns an empty dictionary.
         """
-        self.log(f"Initializing grouping of multicast configs by 'fabricId': {payload_list}.", "INFO")
+        self.log(f"Initializing grouping of multicast configs by fabric ID: {payload_list}.", "INFO")
 
         if not isinstance(payload_list, list):
             self.log(f"Invalid input: 'payload_list' must be a list. Received: {type(payload_list).__name__}", "ERROR")
@@ -3388,15 +3388,15 @@ class FabricMulticast(DnacBase):
         for item in payload_list:
             fabric_id = item.get("fabricId")
             if fabric_id is None:
-                self.log(f"Skipping item without 'fabricId': {item}", "WARNING")
+                self.log(f"Skipping item without fabric ID: {item}", "WARNING")
                 continue
             if fabric_id not in grouped_payload:
-                self.log(f"New 'fabricId' found: {fabric_id}. Initializing grouping.", "DEBUG")
+                self.log(f"New fabric ID found: {fabric_id}. Initializing grouping.", "DEBUG")
                 grouped_payload[fabric_id] = []
 
             grouped_payload[fabric_id].append(item)
 
-        self.log(f"Completed grouping by 'fabricId'. Result: {self.pprint(grouped_payload)}", "DEBUG")
+        self.log(f"Completed grouping by fabric ID. Result: {self.pprint(grouped_payload)}", "DEBUG")
 
         return grouped_payload
 


### PR DESCRIPTION
## Description  
Multicast API currently does not support creating configurations for multiple fabric sites in a single call. This leads to a `400 Bad Request` error when such input is provided.  

This change introduces logic in the module to group payloads by `fabricId` and invoke the creation API separately for each fabric site. This allows users to provide a multi-site input while internally ensuring API compatibility.  

Additionally, similar handling has been added for the multicast update flow.

## Type of Change  
- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Checklist  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  
- [x] All the sanity checks have been completed and the sanity test cases have been executed  

## Ansible Best Practices  
- [x] Tasks are idempotent (can be run multiple times without changing state)  
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)  
- [x] Playbooks are modular and reusable  
- [x] Handlers are used for actions that need to run on change  

## Documentation  
- [x] All options and parameters are documented clearly.  
- [x] Examples are provided and tested.  
- [x] Notes and limitations are clearly stated.  

## Screenshots (if applicable)  

## Notes to Reviewers  
Please review the handling of grouped multicast payloads by `fabricId`. The logic ensures no change in behavior for single-site payloads while enabling safe multi-site operations in line with API limitations.
