### PR TITLE
Bug Fix: SDA Fabric Devices, Removing provisioning check for deleted state. 

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2828,9 +2828,20 @@ class FabricDevices(DnacBase):
                     "proceeding with provisioning checks.".format(ip=fabric_device_ip),
                     "DEBUG",
                 )
-                self.check_device_is_provisioned(
-                    fabric_device_ip, network_device_id, site_id, fabric_name
-                ).check_return_status()
+                state = self.params.get("state")
+                if state == "deleted":
+                    self.log(
+                        f"The state is 'deleted', so skipping the provisioning checks for the device with the IP '{fabric_device_ip}'.",
+                        "DEBUG",
+                    )
+                else:
+                    self.log(
+                        f"Checking if the device with the IP '{fabric_device_ip}' is provisioned in the fabric '{fabric_name}'.",
+                        "DEBUG",
+                    )
+                    self.check_device_is_provisioned(
+                        fabric_device_ip, network_device_id, site_id, fabric_name
+                    ).check_return_status()
             else:
                 self.log(
                     "The device with the IP '{ip}' is a Wireless Controller, "


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

**Bug Fix:**  
When removing devices from the fabric, if a device is already removed (un-provisioned or deleted from inventory), the playbook was failing and terminating with an error like:  
> The network device with the IP address '137.1.23.1' is not provisioned to the site 'Global/Malaysia/Presint 1/Parcel A/AE_Campus_Main'.

**Root Cause:**  
The code always performed provisioning checks for each device, without skipping devices already marked for deletion.

**Fix Implemented:**  
Added a check for `state == "deleted"` to skip provisioning checks if the device is already marked as deleted, so the playbook can continue gracefully with other devices instead of failing.

**Enhancement:**  
Improved resilience of the delete workflow to handle devices that are already removed/un-provisioned.

**Enhancement Description:**  
Instead of terminating on the first un-provisioned device, the playbook now logs a debug message and proceeds with the next device.

**Impact Area:**  
`sda_fabric_devices_workflow_manager.py` module – specifically the part handling deletion of devices from the fabric.

## Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

**Test cases covered:**
- Verified playbook behavior when:
  - Device is already un-provisioned
  - Device is deleted from inventory
  - Device is still in fabric and should be removed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
This fix makes delete playbooks more robust, especially in scenarios where devices might already be removed or un-provisioned by other workflows.
