### PR TITLE
Bug Fix: SDA Fabric Device Workflow Manager: Skip wireless API Calls for fabric zones & update SDK function names after v1 removal from SDK

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -610,12 +610,12 @@ notes:
     - sda.Sda.delete_fabric_device_layer3_handoff_with_ip_transit_by_id
     - task.Task.get_tasks_by_id
     - task.Task.get_task_details_by_id
-    - fabric_wireless.FabricWireless.get_sda_wireless_details_from_switches_v1
-    - wireless.Wireless.get_primary_managed_ap_locations_for_specific_wireless_controller_v1
-    - wireless.Wireless.get_secondary_managed_ap_locations_for_specific_wireless_controller_v1
-    - wireless.Wireless.assign_managed_ap_locations_for_w_l_c_v1
-    - fabric_wireless.Wireless.reload_switch_for_wireless_controller_cleanup_v1
-    - fabric_wireless.Wireless.switch_wireless_setting_and_rolling_ap_upgrade_management_v1
+    - fabric_wireless.FabricWireless.get_sda_wireless_details_from_switches
+    - wireless.Wireless.get_primary_managed_ap_locations_for_specific_wireless_controller
+    - wireless.Wireless.get_secondary_managed_ap_locations_for_specific_wireless_controller
+    - wireless.Wireless.assign_managed_ap_locations_for_w_l_c
+    - fabric_wireless.Wireless.reload_switch_for_wireless_controller_cleanup
+    - fabric_wireless.Wireless.switch_wireless_setting_and_rolling_ap_upgrade_management
 
   - Paths used are
     - GET /dna/intent/api/v1/sites
@@ -1269,6 +1269,7 @@ class FabricDevices(DnacBase):
         )
         self.fabric_l3_handoff_ip_obj_params = self.get_obj_params("fabricIpL3Handoff")
         self.max_timeout = self.params.get("dnac_api_task_timeout")
+        self.fabric_type = None                     # Can be either 'fabric_site' or 'fabric_zone'
 
     def validate_input(self):
         """
@@ -2727,6 +2728,7 @@ class FabricDevices(DnacBase):
         fabric_site_id = self.get_fabric_site_id_from_name(fabric_name, site_id)
         if not fabric_site_id:
             fabric_site_id = self.get_fabric_zone_id_from_name(fabric_name, site_id)
+            self.fabric_type = "fabric_zone"
             if not fabric_site_id:
                 self.msg = "The provided 'fabric_name' '{fabric_name}' is not a valid fabric site.".format(
                     fabric_name=fabric_name
@@ -2748,6 +2750,7 @@ class FabricDevices(DnacBase):
                 "DEBUG",
             )
         else:
+            self.fabric_type = "fabric_site"
             self.log(
                 "Fabric site ID obtained: {fabric_site_id}.".format(
                     fabric_site_id=fabric_site_id
@@ -2881,12 +2884,15 @@ class FabricDevices(DnacBase):
                 f"Fetching wireless controller settings for the fabric '{fabric_name}'.",
                 "DEBUG",
             )
-            wireless_controller_settings = self.get_have_wireless_controller_settings(
-                fabric_name, fabric_site_id, network_device_id, fabric_device_ip
-            )
-            fabric_devices_info.update(
-                {"wireless_controller_settings": wireless_controller_settings}
-            )
+            if self.fabric_type == "fabric_site":
+                wireless_controller_settings = self.get_have_wireless_controller_settings(
+                    fabric_name, fabric_site_id, network_device_id, fabric_device_ip
+                )
+                fabric_devices_info.update(
+                    {"wireless_controller_settings": wireless_controller_settings}
+                )
+            else:
+                self.log(f"Fabric type is '{self.fabric_type}', skipping wireless controller settings retrieval.", "DEBUG")
 
             is_border_device = False
             if "BORDER_NODE" in device_roles:
@@ -3015,12 +3021,12 @@ class FabricDevices(DnacBase):
         try:
             response = self.dnac._exec(
                 family="fabric_wireless",
-                function="get_sda_wireless_details_from_switches_v1",
+                function="get_sda_wireless_details_from_switches",
                 params={"fabric_id": fabric_id},
             )
 
             self.log(
-                f"Received API response from 'get_sda_wireless_details_from_switches_v1' for the fabric '{fabric_name}': {response}",
+                f"Received API response from 'get_sda_wireless_details_from_switches' for the fabric '{fabric_name}': {response}",
                 "DEBUG",
             )
 
@@ -3101,7 +3107,7 @@ class FabricDevices(DnacBase):
             return []
 
         api_function = (
-            f"get_{ap_type}_managed_ap_locations_for_specific_wireless_controller_v1"
+            f"get_{ap_type}_managed_ap_locations_for_specific_wireless_controller"
         )
 
         managed_ap_locations_all = []
@@ -5382,10 +5388,16 @@ class FabricDevices(DnacBase):
                     device_config_index,
                     fabric_name,
                 ),
-                "wireless_controller_settings": self.get_want_wireless_controller_settings(
-                    item, fabric_name, device_ip, device_config_index
-                ),
             }
+            if self.fabric_type == "fabric_site":
+                self.log(f"Gathering wireless controller settings for fabric type: {self.fabric_type}", "DEBUG")
+                fabric_devices_info["wireless_controller_settings"] = self.get_want_wireless_controller_settings(
+                    item, fabric_name, device_ip, device_config_index
+                )
+            else:
+                self.log(f"Skipping wireless controller settings for fabric type: {self.fabric_type}", "DEBUG")
+                fabric_devices_info["wireless_controller_settings"] = None
+
             self.log(
                 "The fabric device with IP '{ip}' details under the site '{site}': {details}".format(
                     ip=device_ip, site=fabric_name, details=fabric_devices_info
@@ -6128,7 +6140,7 @@ class FabricDevices(DnacBase):
             "INFO",
         )
 
-        task_name = "assign_managed_ap_locations_for_w_l_c_v1"
+        task_name = "assign_managed_ap_locations_for_w_l_c"
         primary_managed_ap_locations_site_id = [
             scope_details.get("siteId")
             for scope_details in managed_ap_locations.get(
@@ -6467,7 +6479,7 @@ class FabricDevices(DnacBase):
             f"Constructed API payload for device '{device_ip}': {self.pprint(payload)}",
             "DEBUG",
         )
-        task_name = "switch_wireless_setting_and_rolling_ap_upgrade_management_v1"
+        task_name = "switch_wireless_setting_and_rolling_ap_upgrade_management"
         parameters = payload
 
         task_id = self.get_taskid_post_api_call(
@@ -6526,7 +6538,7 @@ class FabricDevices(DnacBase):
             f"Constructed API payload for device '{device_ip}': {self.pprint(payload)}",
             "DEBUG",
         )
-        task_name = "reload_switch_for_wireless_controller_cleanup_v1"
+        task_name = "reload_switch_for_wireless_controller_cleanup"
         parameters = payload
         task_id = self.get_taskid_post_api_call(
             "fabric_wireless", task_name, parameters
@@ -6926,11 +6938,19 @@ class FabricDevices(DnacBase):
             )
             try:
                 self.update_fabric_devices(fabric_devices).check_return_status()
-                # To Update Wireless Controller Settings, have should be updated with the fabric ID in case of new fabric creation.
-                self.get_have(config)
-                self.update_wireless_controller_settings(
-                    fabric_devices
-                ).check_return_status()
+
+                if self.fabric_type == "fabric_site":
+                    # To Update Wireless Controller Settings, have should be updated with the fabric ID in case of new fabric creation.
+                    self.get_have(config)
+                    self.log("Updating wireless controller settings for fabric type 'fabric_site'.", "DEBUG")
+                    self.update_wireless_controller_settings(
+                        fabric_devices
+                    ).check_return_status()
+                else:
+                    self.log(
+                        f"Skipping wireless controller settings update for fabric type '{self.fabric_type}'.",
+                        "DEBUG",
+                    )
                 self.log("Successfully updated fabric devices.", "INFO")
             except Exception as e:
                 self.log(
@@ -7885,36 +7905,41 @@ class FabricDevices(DnacBase):
                 have_details = self.have.get("fabric_devices")[fabric_device_index]
                 want_details = self.want.get("fabric_devices")[fabric_device_index]
                 if item.get("wireless_controller_settings"):
-                    self.log(
-                        f"Starting verification of wireless controller settings for device with IP '{device_ip}' under fabric '{fabric_name}'.",
-                        "INFO",
-                    )
-                    have_wireless_controller_settings = have_details.get(
-                        "wireless_controller_settings", None
-                    )
-                    want_wireless_controller_settings = want_details.get(
-                        "wireless_controller_settings"
-                    )
-                    enable = want_wireless_controller_settings.get("enable")
-                    if enable:
+                    if self.fabric_type == "fabric_site":
                         self.log(
-                            f"Verifying that wireless controller settings are enabled for device with IP '{device_ip}'.",
-                            "DEBUG",
+                            f"Starting verification of wireless controller settings for device with IP '{device_ip}' under fabric '{fabric_name}'.",
+                            "INFO",
                         )
-                        self.verify_enable_wireless_controller_settings(
-                            have_wireless_controller_settings,
-                            want_wireless_controller_settings,
-                            fabric_name,
-                            device_ip,
-                        ).check_return_status()
+                        have_wireless_controller_settings = have_details.get(
+                            "wireless_controller_settings", None
+                        )
+                        want_wireless_controller_settings = want_details.get(
+                            "wireless_controller_settings"
+                        )
+                        enable = want_wireless_controller_settings.get("enable")
+                        if enable:
+                            self.log(
+                                f"Verifying that wireless controller settings are enabled for device with IP '{device_ip}'.",
+                                "DEBUG",
+                            )
+                            self.verify_enable_wireless_controller_settings(
+                                have_wireless_controller_settings,
+                                want_wireless_controller_settings,
+                                fabric_name,
+                                device_ip,
+                            ).check_return_status()
+                        else:
+                            self.log(
+                                f"Verifying that wireless controller settings are disabled for device with IP '{device_ip}'.",
+                                "DEBUG",
+                            )
+                            self.verify_disable_wireless_controller_settings(
+                                have_wireless_controller_settings, fabric_name, device_ip
+                            ).check_return_status()
                     else:
                         self.log(
-                            f"Verifying that wireless controller settings are disabled for device with IP '{device_ip}'.",
-                            "DEBUG",
+                            f"Skipping wireless controller settings verification for fabric type '{self.fabric_type}'.", "DEBUG"
                         )
-                        self.verify_disable_wireless_controller_settings(
-                            have_wireless_controller_settings, fabric_name, device_ip
-                        ).check_return_status()
 
                 # Verifying whether the IP L3 Handoff is applied to the Cisco Catalyst Center or not
                 if item.get("layer3_handoff_ip_transit"):
@@ -8108,7 +8133,7 @@ class FabricDevices(DnacBase):
         Returns:
             None
         """
-
+        self.fabric_type = None
         self.have.clear()
         self.want.clear()
         return


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: 
Fixed two related bugs — 
(1) wireless controller APIs were incorrectly executed for devices in fabric zones (unsupported), causing 404 errors; 
(2) SDK function names still used old `_v1` suffix after SDK upgrade, leading to failures in multicast and wireless workflows.  

Root Cause: 
(1) The module didn’t check if the fabric type was `fabric_site` vs `fabric_zone` before running wireless logic (wireless only applies to fabric sites); 
(2) SDK was upgraded but code wasn’t updated to new function names.  

Fix Implemented: 
(1) Added `fabric_type` to identify fabric site vs zone and skip wireless controller APIs for zones; 
(2) updated all function names by removing `_v1` suffix to align with SDK 2.10.1; added debug logs for clarity.

Impact Area: `sda_fabric_devices_workflow_manager` module — wireless controller settings retrieval, update, verification, and SDK integration.

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered: Regression test TC#3: Test_TC3_test_EN; manual validation for fabric site and fabric zone scenarios; manual validation of multicast workflows.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
The fix handles both fabric zone wireless API bug and SDK `_v1` function name update; changes are committed in the dev branch.
