### PR TITLE
Updated retrieves_global_ip_address_pools_v1 to retrieves_global_ip_a…

### DIFF
--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -619,7 +619,7 @@ notes:
     network_settings.NetworkSettings.reserve_ip_subpool,
     network_settings.NetworkSettings.update_reserve_ip_subpool,
     network_settings.NetworkSettings.update_network_v2,
-    network_settings.NetworkSettings.retrieves_global_ip_address_pools_v1
+    network_settings.NetworkSettings.retrieves_global_ip_address_pools
     network_settings.NetworkSettings.retrieves_ip_address_subpools_v1
     network_settings.NetworkSettings.create_a_global_ip_address_pool
     network_settings.NetworkSettings.reservecreate_ip_address_subpools_v1
@@ -2425,7 +2425,7 @@ class NetworkSettings(DnacBase):
                 else:
                     response = self.dnac._exec(
                         family="network_settings",
-                        function="retrieves_global_ip_address_pools_v1",
+                        function="retrieves_global_ip_address_pools",
                         params={"offset": offset,
                                 "limit": 500}
                     )
@@ -3046,7 +3046,7 @@ class NetworkSettings(DnacBase):
                 else:
                     response = self.dnac._exec(
                         family="network_settings",
-                        function="retrieves_global_ip_address_pools_v1",
+                        function="retrieves_global_ip_address_pools",
                         params={"offset": offset}
                     )
             except Exception as msg:


### PR DESCRIPTION
…ddress_pools

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
This PR includes bug fix for: 'NetworkSettings' object has no attribute 'retrieves_global_ip_address_pools_v1'

Bug Fix: Updated the API call to use the correct function name for retrieving global IP address pools.
Root Cause: The Cisco DNAC SDK was updated, and the API name retrieves_global_ip_address_pools_v1 was changed to retrieves_global_ip_address_pools. 
Fix Implemented: Replaced all references of retrieves_global_ip_address_pools_v1 with retrieves_global_ip_address_pools in the code to align with the updated SDK function naming.


Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

