### PR TITLE
Bug Fix: SDA Fabric Devices: handle NoneType when adding 'WC' role to ECA device without secondary_managed_ap_locations or rolling_ap_upgrade

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -5216,9 +5216,13 @@ class FabricDevices(DnacBase):
             "primary_managed_ap_locations"
         )
         if primary_managed_ap_locations is None:
-            have_primary_managed_ap_locations = have_wireless_controller_settings.get(
-                "primary_managed_ap_locations"
-            )
+            if have_wireless_controller_settings:
+                have_primary_managed_ap_locations = have_wireless_controller_settings.get(
+                    "primary_managed_ap_locations"
+                )
+            else:
+                have_primary_managed_ap_locations = None
+
             if not have_primary_managed_ap_locations:
                 self.log(
                     "No 'primary_managed_ap_locations' found in both playbook and existing catalyst center config. Setting to empty list.",
@@ -5242,9 +5246,13 @@ class FabricDevices(DnacBase):
             "secondary_managed_ap_locations"
         )
         if secondary_managed_ap_locations is None:
-            have_secondary_managed_ap_locations = have_wireless_controller_settings.get(
-                "secondary_managed_ap_locations"
-            )
+            if have_wireless_controller_settings:
+                have_secondary_managed_ap_locations = have_wireless_controller_settings.get(
+                    "secondary_managed_ap_locations"
+                )
+            else:
+                have_secondary_managed_ap_locations = None
+
             if not have_secondary_managed_ap_locations:
                 secondary_managed_ap_locations = []
                 self.log(
@@ -5266,9 +5274,13 @@ class FabricDevices(DnacBase):
         # ROLLING AP UPGRADE
         rolling_ap_upgrade = want_wireless_controller_settings.get("rolling_ap_upgrade")
         if rolling_ap_upgrade is None:
-            have_rolling_ap_upgrade = have_wireless_controller_settings.get(
-                "rolling_ap_upgrade"
-            )
+            if have_wireless_controller_settings:
+                have_rolling_ap_upgrade = have_wireless_controller_settings.get(
+                    "rolling_ap_upgrade"
+                )
+            else:
+                have_rolling_ap_upgrade = None
+
             if have_rolling_ap_upgrade is None:
                 rolling_ap_upgrade = {"enable": True, "ap_reboot_percentage": 25}
                 self.log(


### PR DESCRIPTION
## Description
Fixed a bug where adding the 'WC' role to an ECA device could cause a NoneType error if the `have` config was empty, missing fields like `secondary_managed_ap_locations`, or when `rolling_ap_upgrade` was disabled.  

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
None
