### PR TITLE
Bug Fix: SDA Fabric Multicast: Fixed issue when more than one external RP (combination of IPv4 and IPv6) can't be set as default

### DIFF
--- a/plugins/modules/sda_fabric_multicast_workflow_manager.py
+++ b/plugins/modules/sda_fabric_multicast_workflow_manager.py
@@ -2222,7 +2222,7 @@ class FabricMulticast(DnacBase):
                 f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
                 "DEBUG"
             )
-            external_ipv4_rp = any(item.get("ex_rp_ipv4_address") and (item.get("is_default_v4_rp") == True) for item in any_source_multicast)
+            external_ipv4_rp = any(item.get("ex_rp_ipv4_address") and (item.get("is_default_v4_rp") is True) for item in any_source_multicast)
             if external_ipv4_rp:
                 self.log(
                     f"External IPv4 RP found in the any-source multicast configurations for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
@@ -2234,7 +2234,7 @@ class FabricMulticast(DnacBase):
                 f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
                 "DEBUG"
             )
-            external_ipv6_rp = any(item.get("ex_rp_ipv6_address") and (item.get("is_default_v6_rp") == True) for item in any_source_multicast)
+            external_ipv6_rp = any(item.get("ex_rp_ipv6_address") and (item.get("is_default_v6_rp") is True) for item in any_source_multicast)
 
             if external_ipv6_rp:
                 self.log(

--- a/plugins/modules/sda_fabric_multicast_workflow_manager.py
+++ b/plugins/modules/sda_fabric_multicast_workflow_manager.py
@@ -2208,7 +2208,49 @@ class FabricMulticast(DnacBase):
 
         multicast_rps = []
 
-        default_allowed = (len(any_source_multicast) == 1)
+        default_allowed = False
+        if len(any_source_multicast) == 1:
+            self.log(
+                "Only one any-source multicast configuration provided. "
+                f"Default allowed for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
+                "DEBUG"
+            )
+            default_allowed = True
+        elif len(any_source_multicast) == 2 and all(item.get("rp_device_location") == "EXTERNAL" for item in any_source_multicast):
+            self.log(
+                "Checking if IPv4 external RP are present in the any-source multicast configurations "
+                f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
+                "DEBUG"
+            )
+            external_ipv4_rp = any(item.get("ex_rp_ipv4_address") for item in any_source_multicast)
+            if external_ipv4_rp:
+                self.log(
+                    f"External IPv4 RP found in the any-source multicast configurations for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
+                    "DEBUG"
+                )
+
+            self.log(
+                "Checking if IPv6 external RP are present in the any-source multicast configurations "
+                f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
+                "DEBUG"
+            )
+            external_ipv6_rp = any(item.get("ex_rp_ipv6_address") for item in any_source_multicast)
+
+            if external_ipv6_rp:
+                self.log(
+                    f"External IPv6 RP found in the any-source multicast configurations for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
+                    "DEBUG"
+                )
+
+            # If both external IPv4 and IPv6 RPs are present, default is allowed
+            if external_ipv4_rp and external_ipv6_rp:
+                self.log(
+                    "Both external IPv4 and IPv6 RPs are present in the any-source multicast configurations. "
+                    f"Default allowed for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
+                    "DEBUG"
+                )
+                default_allowed = True
+
         for item in any_source_multicast:
             rendezvous_point = {}
             rp_device_location = item.get("rp_device_location")

--- a/plugins/modules/sda_fabric_multicast_workflow_manager.py
+++ b/plugins/modules/sda_fabric_multicast_workflow_manager.py
@@ -2222,7 +2222,7 @@ class FabricMulticast(DnacBase):
                 f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
                 "DEBUG"
             )
-            external_ipv4_rp = any(item.get("ex_rp_ipv4_address") for item in any_source_multicast)
+            external_ipv4_rp = any(item.get("ex_rp_ipv4_address") and (item.get("is_default_v4_rp") == True) for item in any_source_multicast)
             if external_ipv4_rp:
                 self.log(
                     f"External IPv4 RP found in the any-source multicast configurations for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}'.",
@@ -2234,7 +2234,7 @@ class FabricMulticast(DnacBase):
                 f"for for L3 VN '{layer3_virtual_network}' under fabric '{fabric_name}",
                 "DEBUG"
             )
-            external_ipv6_rp = any(item.get("ex_rp_ipv6_address") for item in any_source_multicast)
+            external_ipv6_rp = any(item.get("ex_rp_ipv6_address") and (item.get("is_default_v6_rp") == True) for item in any_source_multicast)
 
             if external_ipv6_rp:
                 self.log(


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: Fixed an issue where the SDA multicast workflow was failing when both IPv4 and IPv6 external RPs were configured as default RPs for the same L3 VN.  

Root Cause (if applicable): The existing logic only allowed `is_default_v4_rp` to be true if there was exactly one any-source multicast RP configured; it didn't correctly handle the scenario when both external IPv4 and IPv6 RPs were present as default RPs.
  
Fix Implemented: Enhanced the default RP validation logic to allow default when both external IPv4 and IPv6 RPs are configured under the same any-source multicast list.

Enhancement: Improved debug logging for better traceability when validating default RP eligibility.  
Enhancement Description: Added logs to trace presence of external IPv4 and IPv6 RPs and why default was allowed or denied, improving debuggability for complex multicast configurations.  
Impact Area: SDA multicast workflow manager (`sda_fabric_multicast_workflow_manager.py`).

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered:  
- Verified successful config push with both IPv4 and IPv6 external RPs present.
- Verified config push fails gracefully when RP config is invalid.
- Verified existing scenarios with single RP or only IPv4/IPv6 continue to work.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
Please focus on reviewing the new default RP validation logic and check if additional edge cases need handling.
