### PR TITLE
Bug Fix: SDA Fabric Multicast: handle API limitation for multi-site replication mode updates

### DIFF
--- a/plugins/modules/sda_fabric_multicast_workflow_manager.py
+++ b/plugins/modules/sda_fabric_multicast_workflow_manager.py
@@ -3243,9 +3243,12 @@ class FabricMulticast(DnacBase):
                 ),
                 "INFO",
             )
-            self.bulk_update_replication_mode(
-                to_update_replication_mode
-            ).check_return_status()
+            for item in to_update_replication_mode:
+                self.log(
+                    f"Updating replication mode for fabric ID '{item['fabricId']}': {item}",
+                    "DEBUG",
+                )
+                self.bulk_update_replication_mode([item]).check_return_status()
 
         if to_update:
             self.log(


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: Fixed an issue where creating multicast across multiple sites in a single API call returned an error despite successful creation.
Root Cause (if applicable): The SDA `update_multicast` API has a limitation and only accepts a single object per request. Passing multiple objects in the payload triggered a `400 Bad Request` error: "Too many objects present in the request list."
Fix Implemented: Updated logic to iterate over the list and call `bulk_update_replication_mode` separately for each site, ensuring compliance with the API and correct status reporting.

Enhancement: N/A
Enhancement Description: N/A
Impact Area: SDA Fabric Multicast workflow manager module (`sda_fabric_multicast_workflow_manager.py`)

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered:
- Verified multicast creation with multiple sites sequentially.
- Ensured no error is returned after successful creation.
- Confirmed correct logging of individual fabric updates.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

