### PR TITLE
Fix typo in check_return_status method calls across multiple playbook config generator modules

### DIFF
--- a/plugins/modules/device_credential_playbook_config_generator.py
+++ b/plugins/modules/device_credential_playbook_config_generator.py
@@ -2581,7 +2581,7 @@ def main():
         ccc_device_credential_playbook_config_generator.msg = "State {0} is invalid".format(
             state
         )
-        ccc_device_credential_playbook_config_generator.check_recturn_status()
+        ccc_device_credential_playbook_config_generator.check_return_status()
 
     # Validate the input parameters and check the return statusk
     ccc_device_credential_playbook_config_generator.validate_input().check_return_status()

--- a/plugins/modules/inventory_playbook_config_generator.py
+++ b/plugins/modules/inventory_playbook_config_generator.py
@@ -4257,7 +4257,7 @@ def main():
         ccc_inventory_playbook_generator.msg = "State {0} is invalid".format(
             state
         )
-        ccc_inventory_playbook_generator.check_recturn_status()
+        ccc_inventory_playbook_generator.check_return_status()
 
     # Validate the input parameters and check the return statusk
     ccc_inventory_playbook_generator.validate_input().check_return_status()

--- a/plugins/modules/sda_fabric_multicast_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_multicast_playbook_config_generator.py
@@ -1622,7 +1622,7 @@ def main():
         ccc_sda_multicast_playbook_generator.log(
             ccc_sda_multicast_playbook_generator.msg, "ERROR"
         )
-        ccc_sda_multicast_playbook_generator.check_recturn_status()
+        ccc_sda_multicast_playbook_generator.check_return_status()
 
     # Validate the input parameters and check the return status
     ccc_sda_multicast_playbook_generator.validate_input().check_return_status()

--- a/plugins/modules/sda_fabric_transits_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_transits_playbook_config_generator.py
@@ -897,7 +897,7 @@ def main():
         config_generator.msg = "State {0} is invalid".format(
             state
         )
-        config_generator.check_recturn_status()
+        config_generator.check_return_status()
 
     # Validate the input parameters and check the return statusk
     config_generator.validate_input().check_return_status()

--- a/plugins/modules/wired_campus_automation_playbook_config_generator.py
+++ b/plugins/modules/wired_campus_automation_playbook_config_generator.py
@@ -4953,7 +4953,7 @@ def main():
         ccc_wired_campus_automation_playbook_generator.msg = (
             "State {0} is invalid".format(state)
         )
-        ccc_wired_campus_automation_playbook_generator.check_recturn_status()
+        ccc_wired_campus_automation_playbook_generator.check_return_status()
 
     # Validate the input parameters and check the return statusk
     ccc_wired_campus_automation_playbook_generator.validate_input().check_return_status()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

### Summary
A typo in the `main()` function of multiple playbook config generator modules causes an `AttributeError` crash when an invalid `state` value is provided, instead of returning a proper error message.

### Steps to Reproduce
1. Use any of the affected modules with an invalid `state` value (e.g., `state: invalid_state`).
2. Run the playbook.
3. Observe crash instead of a clean error message.

### Observed Behavior
`AttributeError: 'ClassName' object has no attribute 'check_recturn_status'`

### Expected Behavior
Module exits cleanly with: `"State <value> is invalid"`

### Root Cause Analysis
Typo: `check_recturn_status()` used instead of `check_return_status()` in the invalid-state branch of `main()` across 5 modules.

### Workaround
Avoid passing invalid `state` values.

### Fix Details
Renamed `check_recturn_status()` → `check_return_status()` in the following files:
- `plugins/modules/device_credential_playbook_config_generator.py`
- `plugins/modules/inventory_playbook_config_generator.py`
- `plugins/modules/sda_fabric_multicast_playbook_config_generator.py`
- `plugins/modules/sda_fabric_transits_playbook_config_generator.py`
- `plugins/modules/wired_campus_automation_playbook_config_generator.py`

### Impact
Low severity, isolated to invalid-state error handling path. Does not affect normal operation.

### Additional Information
- DNAC Version: 3.1.6
- cisco.dnac: 6.48.0
- ansible.utils: 6.0.0

## Testing Done
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

**Test cases covered:** Triggered invalid state in each affected module and verified clean error exit.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)
N/A

## Notes to Reviewers
Pure typo fix — one-character change per file, no logic changes.
