### PR TITLE
Enhance input validation for configuration in SdaFabricDevicesPlaybookGenerator

### DIFF
--- a/plugins/modules/sda_fabric_devices_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_devices_playbook_config_generator.py
@@ -499,13 +499,31 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
         """
         self.log("Starting validation of input configuration parameters.", "DEBUG")
 
-        # Check if configuration is available or empty - if not provided or empty, treat as generate_all
-        if not self.config:
-            self.status = "success"
+        # Check if config is provided but empty - this is an error
+        if isinstance(self.config, dict) and len(self.config) == 0:
+            self.msg = (
+                "Configuration cannot be an empty dictionary. "
+                "Either omit 'config' entirely to generate all configurations, "
+                "or provide specific filters within 'config'."
+            )
+            self.log(self.msg, "ERROR")
+            self.set_operation_result("failed", False, self.msg, "ERROR")
+            return self
+
+        # Check if configuration is not provided (None) - treat as generate_all
+        if self.config is None:
             self.validated_config = {"generate_all_configurations": True}
-            self.msg = "Configuration is not provided or empty - treating as generate_all_configurations mode"
+            self.msg = "Configuration is not provided - treating as generate_all_configurations mode"
             self.log(self.msg, "INFO")
             self.set_operation_result("success", False, self.msg, "INFO")
+            return self
+
+        if not isinstance(self.config, dict):
+            self.msg = (
+                f"Configuration must be a dictionary, got: {type(self.config).__name__}. Please provide "
+                "configuration as a dictionary."
+            )
+            self.set_operation_result("failed", False, self.msg, "ERROR")
             return self
 
         # Expected schema for configuration parameters (no file_path, file_mode, or generate_all_configurations)
@@ -527,9 +545,7 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
 
         # Set the validated configuration and update the result with success status
         self.validated_config = valid_temp
-        self.msg = "Successfully validated playbook configuration parameters using 'validated_input': {0}".format(
-            str(valid_temp)
-        )
+        self.msg = f"Successfully validated playbook configuration parameters using 'validated_input': {valid_temp}"
         self.set_operation_result("success", False, self.msg, "INFO")
         return self
 


### PR DESCRIPTION

## Type of Change
- [x] Bug fix

## Description

**Summary:** `validate_input` used `if not self.config:` which treated both `None` and `{}` as falsy, silently falling into `generate_all_configurations` mode even when an empty dict was explicitly passed.

**Steps to Reproduce:** Pass `config: {}` to `sda_fabric_devices_playbook_config_generator` — module runs in generate-all mode with no error.

**Observed Behavior:** `config: {}` silently triggers `generate_all_configurations` mode.

**Expected Behavior:** `config: {}` should fail with a clear error; only `config: null`/omitted should trigger generate-all mode.

**Root Cause:** `not {}` and `not None` are both `True` in Python — no distinction between missing vs. empty config.

**Fix Details:** Replaced the single falsy check with three explicit guards: empty dict → fail, `None` → generate-all, non-dict → fail. Also updated string formatting to f-string.

**File changed:** `plugins/modules/sda_fabric_devices_playbook_config_generator.py`

**Impact:** Any playbook passing `config: {}` expecting generate-all behavior will now fail. Intentional breaking fix for incorrect usage.

## Testing Done
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

**Test cases:** `config: {}` → fail | `config` omitted → generate-all | non-dict config → fail | valid config → success

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] All sanity checks have been completed

## Notes to Reviewers
Verify no existing playbooks pass `config: {}` relying on the old silent fallback. The `None`/omitted path is unchanged.
