### PR TITLE
Handling invalid transit type

### DIFF
--- a/plugins/modules/sda_fabric_transits_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_transits_playbook_config_generator.py
@@ -89,8 +89,8 @@ options:
               transit_type:
                 description:
                 - Transit type to filter fabric transits by type.
-                - Valid values are IP_BASED_TRANSIT, SDA_LISP_PUB_SUB_TRANSIT, SDA_LISP_BGP_TRANSIT
                 type: str
+                choices: [IP_BASED_TRANSIT, SDA_LISP_PUB_SUB_TRANSIT, SDA_LISP_BGP_TRANSIT]
 
 requirements:
 - dnacentersdk >= 2.3.7.9
@@ -425,7 +425,14 @@ class SdaFabricTransitsPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "sda_fabric_transits": {
                     "filters": {
                         "name": {"type": "str"},
-                        "transit_type": {"type": "str"}
+                        "transit_type": {
+                            "type": "str",
+                            "choices": [
+                                "IP_BASED_TRANSIT",
+                                "SDA_LISP_PUB_SUB_TRANSIT",
+                                "SDA_LISP_BGP_TRANSIT"
+                            ]
+                        }
                     },
                     "reverse_mapping_function": self.fabric_transit_temp_spec,
                     "api_function": "get_transit_networks",

--- a/plugins/modules/sda_fabric_transits_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_transits_playbook_config_generator.py
@@ -89,8 +89,19 @@ options:
               transit_type:
                 description:
                 - Transit type to filter fabric transits by type.
+                - C(IP_BASED_TRANSIT) selects transits that
+                  use IP-based routing with BGP between
+                  fabric sites.
+                - C(SDA_LISP_PUB_SUB_TRANSIT) selects
+                  transits that use SDA with LISP
+                  Publish-Subscribe control plane.
+                - C(SDA_LISP_BGP_TRANSIT) selects transits
+                  that use SDA with LISP BGP control plane.
                 type: str
-                choices: [IP_BASED_TRANSIT, SDA_LISP_PUB_SUB_TRANSIT, SDA_LISP_BGP_TRANSIT]
+                choices:
+                - IP_BASED_TRANSIT
+                - SDA_LISP_PUB_SUB_TRANSIT
+                - SDA_LISP_BGP_TRANSIT
 
 requirements:
 - dnacentersdk >= 2.3.7.9

--- a/tests/unit/modules/dnac/fixtures/sda_fabric_transits_playbook_config_generator.json
+++ b/tests/unit/modules/dnac/fixtures/sda_fabric_transits_playbook_config_generator.json
@@ -176,6 +176,15 @@
       ]
     }
   },
+  "playbook_config_invalid_transit_type": {
+    "component_specific_filters": {
+      "sda_fabric_transits": [
+        {
+          "transit_type": "invalid_transit_type"
+        }
+      ]
+    }
+  },
   "get_device_details": {
     "response": [
       {

--- a/tests/unit/modules/dnac/test_sda_fabric_transits_playbook_config_generator.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_transits_playbook_config_generator.py
@@ -52,6 +52,7 @@ class TestSdaFabricTransitsPlaybookConfigGenerator(TestDnacModule):
     playbook_config_empty_component_specific_filters = test_data.get("playbook_config_empty_component_specific_filters")
     playbook_config_invalid_component = test_data.get("playbook_config_invalid_component")
     playbook_config_invalid_component_filters = test_data.get("playbook_config_invalid_component_filters")
+    playbook_config_invalid_transit_type = test_data.get("playbook_config_invalid_transit_type")
 
     def setUp(self):
         super(TestSdaFabricTransitsPlaybookConfigGenerator, self).setUp()
@@ -199,6 +200,9 @@ class TestSdaFabricTransitsPlaybookConfigGenerator(TestDnacModule):
             # No side effects needed - validation happens before API calls
             pass
         elif "invalid_component_filters" in self._testMethodName:
+            # No side effects needed - validation happens before API calls
+            pass
+        elif "invalid_transit_type" in self._testMethodName:
             # No side effects needed - validation happens before API calls
             pass
 
@@ -633,3 +637,32 @@ class TestSdaFabricTransitsPlaybookConfigGenerator(TestDnacModule):
         )
         result = self.execute_module(changed=False, failed=True)
         self.assertIn("Invalid filters provided for module", str(result.get("msg")))
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.path.exists')
+    def test_sda_fabric_transits_playbook_config_generator_invalid_transit_type(self, mock_exists, mock_file):
+        """
+        Test case for invalid transit type in component_specific_filters.
+
+        This test verifies that the generator correctly fails when
+        an invalid transit type is provided in the filters for sda_fabric_transits.
+        """
+        mock_exists.return_value = True
+
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="2.3.7.9",
+                dnac_log=True,
+                state="gathered",
+                config=self.playbook_config_invalid_transit_type
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        self.assertIn("Invalid filters provided for module", str(result.get("msg")))
+        self.assertIn(
+            "Valid choices: ['IP_BASED_TRANSIT', 'SDA_LISP_PUB_SUB_TRANSIT', 'SDA_LISP_BGP_TRANSIT']",
+            str(result.get("msg"))
+        )


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Currently, the module not validating the invalid transit type in config generator module. If we pass invalid transit type, getting API error.

## Fix

The module now validates the transit_type parameter before making the API call.
If an invalid transit_type is provided, the module returns a clear and proper error message indicating the invalid parameter and allowed values 
Allowed values: IP_BASED_TRANSIT, SDA_LISP_PUB_SUB_TRANSIT and SDA_LISP_BGP_TRANSIT

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

