### PR TITLE
Bug fix/sda fabric devices pcg

### DIFF
--- a/playbooks/sda_fabric_devices_playbook_config_generator.yaml
+++ b/playbooks/sda_fabric_devices_playbook_config_generator.yaml
@@ -94,7 +94,7 @@
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
+              - fabric_name: "Global/USA/SAN-JOSE"
 
 # Example 4: Generate configuration for devices with specific roles in a fabric site
 - name: Generate configuration for border and control plane devices
@@ -124,8 +124,8 @@
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
-              device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
+              - fabric_name: "Global/USA/SAN-JOSE"
+                device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
 
 # Example 5: Generate configuration for a specific device in a fabric site
 - name: Generate configuration for a specific fabric device
@@ -155,8 +155,8 @@
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
-              device_ip: "10.0.0.1"
+              - fabric_name: "Global/USA/SAN-JOSE"
+                device_ip: "10.0.0.1"
 
 # Example 6: Auto-populate components_list from component filters
 - name: Generate configuration with auto-populated components_list
@@ -187,7 +187,7 @@
             # No components_list specified, but fabric_devices filters are provided
             # The 'fabric_devices' component will be automatically added to components_list
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
+              - fabric_name: "Global/USA/SAN-JOSE"
 
 # Example 7: Generate configuration with append mode
 - name: Generate and append SDA fabric device configuration
@@ -217,5 +217,5 @@
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/India/Bangalore"
-              device_roles: ["BORDER_NODE"]
+              - fabric_name: "Global/India/Bangalore"
+                device_roles: ["BORDER_NODE"]

--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -361,6 +361,15 @@ class BrownFieldHelper:
                     )
                     continue
 
+                # Check for missing required filters in this entry
+                for req_filter_name, req_filter_spec in valid_filters_for_component.items():
+                    if req_filter_spec.get("required", False) and req_filter_name not in component_filter:
+                        invalid_filters.append(
+                            "Component '{0}' filter entry {1}/{2} is missing required filter '{3}'".format(
+                                component_name, index, len(component_filters), req_filter_name
+                            )
+                        )
+
                 for filter_name, filter_value in component_filter.items():
                     self.log(
                         "Processing filter '{0}' in entry {1}/{2} for component '{3}': value={4}".format(

--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -290,8 +290,9 @@ class BrownFieldHelper:
                 comp for comp in components_list if comp not in network_elements
             ]
             if invalid_components:
+                valid_components = list(network_elements.keys()) + ["component_list"]
                 self.msg = "Invalid network components provided for module '{0}': {1}. Valid components are: {2}".format(
-                    self.module_name, invalid_components, list(network_elements.keys())
+                    self.module_name, invalid_components, valid_components
                 )
                 self.fail_and_exit(self.msg)
 

--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -290,7 +290,7 @@ class BrownFieldHelper:
                 comp for comp in components_list if comp not in network_elements
             ]
             if invalid_components:
-                valid_components = list(network_elements.keys()) + ["component_list"]
+                valid_components = list(network_elements.keys()) + ["components_list"]
                 self.msg = "Invalid network components provided for module '{0}': {1}. Valid components are: {2}".format(
                     self.module_name, invalid_components, valid_components
                 )

--- a/plugins/modules/sda_fabric_devices_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_devices_playbook_config_generator.py
@@ -1122,15 +1122,25 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
 
     def get_fabric_devices_configuration(self, network_element, filters=None):
         """
-        Retrieve and transform fabric devices configuration.
+        Retrieve and transform fabric devices configuration into playbook-ready format.
 
         Parameters:
-            network_element (dict): Network element schema with API and transform details.
-            filters (dict, optional): Dictionary containing 'component_specific_filters'.
-                - component_specific_filters (list/dict): Filters for fabric_name, device_ip, device_roles.
+            network_element (dict): Network element schema containing:
+                - api_family (str): API family to use (e.g. 'sda').
+                - api_function (str): API function name (e.g. 'get_fabric_devices').
+                - reverse_mapping_function (callable): Returns the temp_spec OrderedDict for transformation.
+            filters (dict, optional): Dictionary containing:
+                - component_specific_filters (list of dict): Each entry may include:
+                    - fabric_name (str): Name of the fabric site to filter by.
+                    - device_ip (str): IP address of a specific device to filter by.
+                    - device_roles (list of str): Roles to filter by (e.g. 'BORDER_NODE').
+                  If omitted or None, all fabric sites and their devices are retrieved.
 
         Returns:
-            dict: Dictionary with 'fabric_devices' key containing transformed device configs.
+            dict: Dictionary with key 'fabric_devices' mapping to a list of transformed fabric
+                  site entries, each containing fabric_name and device_config list.
+            None: If no valid query parameters could be built from the provided filters, or if
+                  no fabric devices are found matching the filters.
 
         Description:
             Main function to fetch fabric devices and transform them to playbook format.
@@ -1241,6 +1251,12 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
                 )
                 fabric_devices_params_list_to_query.append({"fabric_id": fabric_id})
 
+        if not fabric_devices_params_list_to_query:
+            self.log(
+                "No fabric devices parameters to query, Returning None"
+            )
+            return None
+
         self.log(
             f"Total fabric device queries to execute: {len(fabric_devices_params_list_to_query)}",
             "INFO",
@@ -1265,10 +1281,10 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
 
         if not all_fabric_devices:
             self.log(
-                "No fabric devices found matching the provided filters",
+                "No fabric devices found matching the provided filters, Returning None",
                 "WARNING",
             )
-            return {"fabric_devices": []}
+            return None
 
         self.log(
             f"Successfully retrieved {len(all_fabric_devices)} fabric device(s) for the provided filters",
@@ -1357,6 +1373,11 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
         transformed_fabric_devices_list = self.modify_parameters(
             temp_spec, fabric_entries_for_transformation
         )
+        if not transformed_fabric_devices_list:
+            self.log(
+                "No fabric devices were transformed successfully, returning None",
+            )
+            return None
 
         self.log(
             f"Transformation complete. Generated {len(transformed_fabric_devices_list)} fabric site(s) with devices",

--- a/plugins/modules/sda_fabric_devices_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_devices_playbook_config_generator.py
@@ -88,6 +88,10 @@ options:
             - Used to narrow down which fabric sites and devices should be included in the generated YAML file.
             - If no filters are provided, all fabric devices from all fabric sites in Cisco Catalyst Center will be retrieved.
             - Each list entry targets a specific fabric site and optionally narrows down by device IP or roles.
+            - Within a single entry, all specified filters are combined using AND
+              logic. Omitting a filter means no restriction on that attribute.
+            - Multiple entries are combined using OR logic, allowing retrieval from
+              different fabric sites in a single invocation.
             type: list
             elements: dict
             suboptions:
@@ -360,6 +364,37 @@ EXAMPLES = r"""
             fabric_devices:
               - fabric_name: "Global/India/Bangalore"
                 device_roles: ["BORDER_NODE"]
+
+# Example 8: Generate configuration for devices from multiple fabric sites
+- name: Generate configuration from multiple fabric sites
+  hosts: dnac_servers
+  vars_files:
+    - credentials.yml
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Export fabric devices from two fabric sites
+      cisco.dnac.sda_fabric_devices_playbook_config_generator:
+        dnac_host: "{{ dnac_host }}"
+        dnac_port: "{{ dnac_port }}"
+        dnac_username: "{{ dnac_username }}"
+        dnac_password: "{{ dnac_password }}"
+        dnac_verify: "{{ dnac_verify }}"
+        dnac_debug: "{{ dnac_debug }}"
+        dnac_version: "{{ dnac_version }}"
+        dnac_log: true
+        dnac_log_level: DEBUG
+        dnac_log_append: false
+        dnac_log_file_path: "{{ dnac_log_file_path }}"
+        state: gathered
+        config:
+          component_specific_filters:
+            components_list: ["fabric_devices"]
+            fabric_devices:
+              - fabric_name: "Global/USA/SAN-JOSE"
+                device_roles: ["BORDER_NODE"]
+              - fabric_name: "Global/India/Bangalore"
+                device_roles: ["EDGE_NODE"]
 """
 
 RETURN = r"""

--- a/plugins/modules/sda_fabric_devices_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_devices_playbook_config_generator.py
@@ -87,7 +87,9 @@ options:
             - Filters specific to fabric device configuration retrieval.
             - Used to narrow down which fabric sites and devices should be included in the generated YAML file.
             - If no filters are provided, all fabric devices from all fabric sites in Cisco Catalyst Center will be retrieved.
-            type: dict
+            - Each list entry targets a specific fabric site and optionally narrows down by device IP or roles.
+            type: list
+            elements: dict
             suboptions:
               fabric_name:
                 description:
@@ -233,7 +235,7 @@ EXAMPLES = r"""
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
+              - fabric_name: "Global/USA/SAN-JOSE"
 
 # Example 4: Generate configuration for devices with specific roles in a fabric site
 - name: Generate configuration for border and control plane devices
@@ -263,8 +265,8 @@ EXAMPLES = r"""
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
-              device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
+              - fabric_name: "Global/USA/SAN-JOSE"
+                device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
 
 # Example 5: Generate configuration for a specific device in a fabric site
 - name: Generate configuration for a specific fabric device
@@ -294,8 +296,8 @@ EXAMPLES = r"""
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
-              device_ip: "10.0.0.1"
+              - fabric_name: "Global/USA/SAN-JOSE"
+                device_ip: "10.0.0.1"
 
 # Example 6: Auto-populate components_list from component filters
 - name: Generate configuration with auto-populated components_list
@@ -326,7 +328,7 @@ EXAMPLES = r"""
             # No components_list specified, but fabric_devices filters are provided
             # The 'fabric_devices' component will be automatically added to components_list
             fabric_devices:
-              fabric_name: "Global/USA/SAN-JOSE"
+              - fabric_name: "Global/USA/SAN-JOSE"
 
 # Example 7: Generate configuration with append mode
 - name: Generate and append SDA fabric device configuration
@@ -356,8 +358,8 @@ EXAMPLES = r"""
           component_specific_filters:
             components_list: ["fabric_devices"]
             fabric_devices:
-              fabric_name: "Global/India/Bangalore"
-              device_roles: ["BORDER_NODE"]
+              - fabric_name: "Global/India/Bangalore"
+                device_roles: ["BORDER_NODE"]
 """
 
 RETURN = r"""
@@ -1154,74 +1156,79 @@ class SdaFabricDevicesPlaybookGenerator(DnacBase, BrownFieldHelper):
 
         if component_specific_filters:
             self.log(
-                "Processing component-specific filters",
+                f"Processing {len(component_specific_filters)} component-specific filter(s)",
                 "DEBUG",
             )
-            params_for_query = {}
+            for filter_idx, filter_entry in enumerate(component_specific_filters, 1):
+                self.log(
+                    f"Processing filter entry {filter_idx}/{len(component_specific_filters)}: {self.pprint(filter_entry)}",
+                    "DEBUG",
+                )
+                params_for_query = {}
 
-            fabric_name = component_specific_filters.get("fabric_name")
-            if fabric_name:
-                self.log(f"Applying fabric_name filter: '{fabric_name}'", "DEBUG")
-                fabric_site_id = self.fabric_site_name_to_id_dict.get(fabric_name)
+                fabric_name = filter_entry.get("fabric_name")
+                if fabric_name:
+                    self.log(f"Applying fabric_name filter: '{fabric_name}'", "DEBUG")
+                    fabric_site_id = self.fabric_site_name_to_id_dict.get(fabric_name)
 
-                if not fabric_site_id:
+                    if not fabric_site_id:
+                        self.log(
+                            f"Fabric site '{fabric_name}' not found in Cisco Catalyst Center. Skipping filter entry {filter_idx}.",
+                            "WARNING",
+                        )
+                        continue
+
                     self.log(
-                        f"Fabric site '{fabric_name}' not found in Cisco Catalyst Center.",
+                        f"Fabric site '{fabric_name}' found with fabric_id '{fabric_site_id}'",
+                        "DEBUG",
+                    )
+                    params_for_query["fabric_id"] = fabric_site_id
+
+                device_ip = filter_entry.get("device_ip")
+                if device_ip:
+                    self.log(
+                        f"Applying device_ip filter: '{device_ip}'",
+                        "DEBUG",
+                    )
+                    device_list_params = self.get_device_list_params(
+                        ip_address_list=device_ip
+                    )
+                    device_info_map = self.get_device_list(device_list_params)
+                    if not device_info_map or device_ip not in device_info_map:
+                        self.log(
+                            f"Device with IP '{device_ip}' not found in Cisco Catalyst Center. Skipping filter entry {filter_idx}.",
+                            "WARNING",
+                        )
+                        continue
+
+                    network_device_id = device_info_map[device_ip].get("device_id")
+                    self.log(
+                        f"Device with IP '{device_ip}' found with network_device_id '{network_device_id}'",
+                        "DEBUG",
+                    )
+                    self.log(f"Adding device_id filter: {network_device_id}", "DEBUG")
+                    params_for_query["networkDeviceId"] = network_device_id
+
+                device_roles = filter_entry.get("device_roles")
+                if device_roles:
+                    self.log(
+                        f"Applying device_roles filter: {device_roles}",
+                        "DEBUG",
+                    )
+                    params_for_query["deviceRoles"] = device_roles
+
+                if not params_for_query:
+                    self.log(
+                        f"No valid filters provided for filter entry {filter_idx}, skipping.",
                         "WARNING",
                     )
-                    return {"fabric_devices": []}
+                    continue
 
                 self.log(
-                    f"Fabric site '{fabric_name}' found with fabric_id '{fabric_site_id}'",
+                    f"Adding query parameters to list: {params_for_query}",
                     "DEBUG",
                 )
-                params_for_query["fabric_id"] = fabric_site_id
-
-            device_ip = component_specific_filters.get("device_ip")
-            if device_ip:
-                self.log(
-                    f"Applying device_ip filter: '{device_ip}'",
-                    "DEBUG",
-                )
-                device_list_params = self.get_device_list_params(
-                    ip_address_list=device_ip
-                )
-                device_info_map = self.get_device_list(device_list_params)
-                if not device_info_map or device_ip not in device_info_map:
-                    self.log(
-                        f"Device with IP '{device_ip}' not found in Cisco Catalyst Center.",
-                        "WARNING",
-                    )
-                    return {"fabric_devices": []}
-
-                network_device_id = device_info_map[device_ip].get("device_id")
-                self.log(
-                    f"Device with IP '{device_ip}' found with network_device_id '{network_device_id}'",
-                    "DEBUG",
-                )
-                self.log(f"Adding device_id filter: {network_device_id}", "DEBUG")
-                params_for_query["networkDeviceId"] = network_device_id
-
-            device_roles = component_specific_filters.get("device_roles")
-            if device_roles:
-                self.log(
-                    f"Applying device_roles filter: {device_roles}",
-                    "DEBUG",
-                )
-                params_for_query["deviceRoles"] = device_roles
-
-            if not params_for_query:
-                self.log(
-                    "No valid filters provided after processing component-specific filters.",
-                    "WARNING",
-                )
-                return {"fabric_devices": []}
-
-            self.log(
-                f"Adding query parameters to list: {params_for_query}",
-                "DEBUG",
-            )
-            fabric_devices_params_list_to_query.append(params_for_query)
+                fabric_devices_params_list_to_query.append(params_for_query)
         else:
             self.log(
                 "No component-specific filters provided. Retrieving all fabric devices from all fabric sites.",

--- a/tests/unit/modules/dnac/fixtures/sda_fabric_devices_playbook_config_generator.json
+++ b/tests/unit/modules/dnac/fixtures/sda_fabric_devices_playbook_config_generator.json
@@ -2,73 +2,91 @@
     "generate_all_configurations_case_1": null,
     "filter_fabric_name_only_case_2": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore"
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore"
+                }
+            ]
         }
     },
     "filter_fabric_name_device_ip_case_3": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore",
-                "device_ip": "205.1.1.10"
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_ip": "205.1.1.10"
+                }
+            ]
         }
     },
     "filter_fabric_name_edge_role_case_4": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore",
-                "device_roles": ["EDGE_NODE"]
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_roles": ["EDGE_NODE"]
+                }
+            ]
         }
     },
     "filter_fabric_name_multi_roles_case_5": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore",
-                "device_roles": ["BORDER_NODE", "CONTROL_PLANE_NODE"]
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_roles": ["BORDER_NODE", "CONTROL_PLANE_NODE"]
+                }
+            ]
         }
     },
     "filter_all_filters_case_6": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore",
-                "device_ip": "205.1.1.10",
-                "device_roles": ["BORDER_NODE", "CONTROL_PLANE_NODE"]
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_ip": "205.1.1.10",
+                    "device_roles": ["BORDER_NODE", "CONTROL_PLANE_NODE"]
+                }
+            ]
         }
     },
     "filter_fabric_name_cp_role_case_7": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/India/Telangana/Hyderabad/BLD_1",
-                "device_roles": ["CONTROL_PLANE_NODE"]
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/India/Telangana/Hyderabad/BLD_1",
+                    "device_roles": ["CONTROL_PLANE_NODE"]
+                }
+            ]
         }
     },
     "filter_fabric_name_border_role_case_8": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore",
-                "device_roles": ["BORDER_NODE"]
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_roles": ["BORDER_NODE"]
+                }
+            ]
         }
     },
     "filter_with_components_list_case_9": {
         "component_specific_filters": {
             "components_list": ["fabric_devices"],
-            "fabric_devices": {
-                "fabric_name": "Global/India/Telangana/Hyderabad/BLD_1"
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/India/Telangana/Hyderabad/BLD_1"
+                }
+            ]
         }
     },
     "filter_with_file_mode_append_case_10": {
         "component_specific_filters": {
-            "fabric_devices": {
-                "fabric_name": "Global/Site_India/Karnataka/Bangalore"
-            }
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore"
+                }
+            ]
         }
     },
     "get_sites_case_1": {

--- a/tests/unit/modules/dnac/fixtures/sda_fabric_devices_playbook_config_generator.json
+++ b/tests/unit/modules/dnac/fixtures/sda_fabric_devices_playbook_config_generator.json
@@ -455,6 +455,20 @@
         ],
         "version": "1.0"
     },
+    "filter_multi_fabric_sites_case_11": {
+        "component_specific_filters": {
+            "fabric_devices": [
+                {
+                    "fabric_name": "Global/Site_India/Karnataka/Bangalore",
+                    "device_roles": ["EDGE_NODE"]
+                },
+                {
+                    "fabric_name": "Global/India/Telangana/Hyderabad/BLD_1",
+                    "device_roles": ["CONTROL_PLANE_NODE"]
+                }
+            ]
+        }
+    },
     "get_fabric_devices_filtered_cp_node_fabric_3_case_1": {
         "response": [
             {

--- a/tests/unit/modules/dnac/test_sda_fabric_devices_playbook_config_generator.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_devices_playbook_config_generator.py
@@ -71,6 +71,9 @@ class TestDnacBrownfieldSdaFabricDevicesPlaybookGenerator(TestDnacModule):
     playbook_config_filter_with_file_mode_append_case_10 = test_data.get(
         "filter_with_file_mode_append_case_10"
     )
+    playbook_config_filter_multi_fabric_sites_case_11 = test_data.get(
+        "filter_multi_fabric_sites_case_11"
+    )
 
     def setUp(self):
         super(TestDnacBrownfieldSdaFabricDevicesPlaybookGenerator, self).setUp()
@@ -407,6 +410,50 @@ class TestDnacBrownfieldSdaFabricDevicesPlaybookGenerator(TestDnacModule):
                 self.test_data.get("get_layer3_sda_transit_handoffs_empty_response"),
             ]
 
+        elif "test_filter_multi_fabric_sites_case_11" in self._testMethodName:
+            # Test Case 11: Filter across multiple fabric sites with different role filters
+            # - Bangalore: EDGE_NODE (2 devices)
+            # - Hyderabad: CONTROL_PLANE_NODE (1 device)
+
+            self.run_dnac_exec.side_effect = [
+                # Initialization phase
+                self.test_data.get("get_sites_case_1"),
+                self.test_data.get("get_fabric_sites_case_1"),
+                self.test_data.get("get_transit_networks_case_1"),
+                # get_fabric_devices for Bangalore with EDGE_NODE filter - returns 2 edge nodes
+                self.test_data.get("get_fabric_devices_filtered_edge_nodes_case_1"),
+                # get_network_device_list for 2 edge node devices
+                self.test_data.get("get_device_list_device_1_case_1"),  # 205.1.2.67
+                self.test_data.get("get_device_list_device_3_case_1"),  # 205.1.2.68
+                # get_fabric_site_wired_settings for Bangalore
+                self.test_data.get(
+                    "get_embedded_wireless_controller_settings_empty_response"
+                ),
+                # Border handoff settings for 2 Bangalore edge node devices
+                # Device 1
+                self.test_data.get("get_layer2_handoffs_empty_response"),
+                self.test_data.get("get_layer3_ip_transit_handoffs_empty_response"),
+                self.test_data.get("get_layer3_sda_transit_handoffs_empty_response"),
+                # Device 3
+                self.test_data.get("get_layer2_handoffs_empty_response"),
+                self.test_data.get("get_layer3_ip_transit_handoffs_empty_response"),
+                self.test_data.get("get_layer3_sda_transit_handoffs_empty_response"),
+                # get_fabric_devices for Hyderabad with CONTROL_PLANE_NODE filter - returns 1 device
+                self.test_data.get(
+                    "get_fabric_devices_filtered_cp_node_fabric_3_case_1"
+                ),
+                # get_network_device_list for 1 CP device
+                self.test_data.get("get_device_list_device_5_case_1"),  # 172.27.248.222
+                # get_fabric_site_wired_settings for Hyderabad
+                self.test_data.get(
+                    "get_embedded_wireless_controller_settings_empty_response"
+                ),
+                # Border handoff settings for 1 Hyderabad CP node device
+                self.test_data.get("get_layer2_handoffs_empty_response"),
+                self.test_data.get("get_layer3_ip_transit_handoffs_empty_response"),
+                self.test_data.get("get_layer3_sda_transit_handoffs_empty_response"),
+            ]
+
         elif "test_filter_with_file_mode_append_case_10" in self._testMethodName:
             # Test Case 10: Test file_mode append functionality
             # This tests the append mode parameter (same as case 2 but with append mode)
@@ -728,6 +775,33 @@ class TestDnacBrownfieldSdaFabricDevicesPlaybookGenerator(TestDnacModule):
                 dnac_log_level="DEBUG",
                 file_path="/tmp/ut_case9_with_components_list.yaml",
                 config=self.playbook_config_filter_with_components_list_case_9,
+            )
+        )
+
+        result = self.execute_module(changed=True, failed=False)
+        self.assertIn(
+            "YAML configuration file generated successfully for module 'sda_fabric_devices_workflow_manager'",
+            str(result.get("msg")),
+        )
+
+    def test_filter_multi_fabric_sites_case_11(self):
+        """
+        Test Case 11: Filter across multiple fabric sites with different role filters.
+        - Bangalore: EDGE_NODE (2 devices)
+        - Hyderabad/BLD_1: CONTROL_PLANE_NODE (1 device)
+        Expected: Returns 3 fabric devices total across 2 fabric sites.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="2.3.7.9",
+                dnac_log=True,
+                state="gathered",
+                dnac_log_level="DEBUG",
+                file_path="/tmp/ut_case11_multi_fabric_sites.yaml",
+                config=self.playbook_config_filter_multi_fabric_sites_case_11,
             )
         )
 


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## `fabric_devices` filter must be a list of dicts

**Summary:**
The `fabric_devices` field under `component_specific_filters` was typed and handled as a single dictionary. The `brownfield_helper` validation layer enforces a list type for all component filters, so any playbook supplying `fabric_devices` as a dict would fail immediately with `"Component 'fabric_devices' filters must be a list"`.

**Steps to Reproduce:**
```yaml
config:
  component_specific_filters:
    components_list: ["fabric_devices"]
    fabric_devices:
      fabric_name: "Global/USA/SAN-JOSE"
      device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
```

**Observed Behavior:**
```
Component 'fabric_devices' filters must be a list
```

**Expected Behavior:**
`fabric_devices` should be accepted as a list of filter dictionaries:
```yaml
fabric_devices:
  - fabric_name: "Global/USA/SAN-JOSE"
    device_roles: ["BORDER_NODE", "CONTROL_PLANE_NODE"]
```

**Root Cause Analysis:**
`fabric_devices` was declared as `type: dict` in the module DOCUMENTATION and processed via a single `.get()` call in `get_fabric_devices_configuration`, conflicting with `validate_component_specific_filters` which expects a list of dicts.

**Fix Details:**
- Changed `fabric_devices` type from `dict` to `list / elements: dict` in DOCUMENTATION.
- Updated `get_fabric_devices_configuration` to iterate over the list of filter entries; invalid/not-found entries are skipped with a warning so other valid entries in the same list are still processed.
- Updated all EXAMPLES in the module and `playbooks/sda_fabric_devices_playbook_config_generator.yaml` to use list syntax.
- Updated all fixture entries in `tests/unit/modules/dnac/fixtures/sda_fabric_devices_playbook_config_generator.json` to list format.

**Impact:**
Breaking change for existing playbooks using `fabric_devices` as a dict. All consumers must update to list syntax. The new loop-based approach also enables multiple fabric site filters in a single module invocation.

---

## `fabric_name` required parameter not enforced in `fabric_devices` filter

**Summary:**
`fabric_name` is documented as `required: true` under `fabric_devices` in `component_specific_filters`, but the module executed without error when it was omitted, failing silently later at the API level.

**Steps to Reproduce:**
```yaml
config:
  component_specific_filters:
    components_list: ["fabric_devices"]
    fabric_devices:
      - device_ip: "10.0.0.1"
```

**Observed Behavior:**
Module executes successfully with no validation error, then fails at the API level:
```
Sda.get_fabric_devices() missing 1 required positional argument: 'fabric_id'
```

**Expected Behavior:**
```
Component 'fabric_devices' filter entry 1/1 is missing required filter 'fabric_name'
```

**Root Cause Analysis:**
`validate_component_specific_filters` in `brownfield_helper.py` only iterated over filters that were **present** in the submitted entry. It never checked for filters marked `"required": True` that were **absent**.

**Fix Details:**
Added a required-field check in `validate_component_specific_filters` before the per-filter validation loop. For each filter entry, the code now iterates `valid_filters_for_component` and appends an error for any filter spec with `"required": True` that is missing from the entry.

**Impact:**
Any `fabric_devices` filter entry omitting `fabric_name` is now rejected at validation time with a clear error message. The fix is in the shared `brownfield_helper.py` and applies to all modules using `validate_component_specific_filters`.

---

## Non-existent `fabric_name` generates empty config instead of warning

**Summary:**
When a `fabric_name` that does not exist in Cisco Catalyst Center is supplied, the module silently produced an empty configuration (`fabric_devices: []`) rather than reporting that no matching data was found.

**Steps to Reproduce:**
```yaml
config:
  component_specific_filters:
    components_list: ["fabric_devices"]
    fabric_devices:
      - fabric_name: "Global/USA/New Yorks"   # Non-existent fabric_name
```

**Observed Behavior:**
```yaml
config:
  - fabric_devices: []
```

**Expected Behavior:**
```
No configurations found for module 'sda_fabric_devices_workflow_manager'.
Verify filters and component availability.
```

**Root Cause Analysis:**
`get_fabric_devices_configuration` had two code paths that returned a truthy value when no data was found:
1. When all filter entries were skipped (unresolvable `fabric_name`), execution continued past an empty `fabric_devices_params_list_to_query` and returned a result with an empty list.
2. When the API returned zero devices, the method returned `{"fabric_devices": []}` instead of `None`.

Because `yaml_config_generator` only skips components when `component_data` is falsy, these truthy-but-empty returns were appended to `final_config_list` and written to the YAML file.

**Fix Details:**
Three changes in `get_fabric_devices_configuration`:
1. Added an early-return `None` guard when `fabric_devices_params_list_to_query` is empty after processing all filter entries.
2. Changed `return {"fabric_devices": []}` (no devices found) to `return None`.
3. Added a `None` return guard after `modify_parameters` yields no transformed results.

**Impact:**
Users providing an invalid or non-existent `fabric_name` now receive a clear status message instead of a misleading empty output file.

---

## `component_list` missing from valid-components list in error message

**Summary:**
When an invalid key is provided under `component_specific_filters`, the error message did not include `component_list` in the valid-components hint. Since `component_list` is a valid and expected key, the error gave users an incomplete picture of accepted keys.

**Steps to Reproduce:**
```yaml
config:
  component_specific_filters:
    components_lists: ["fabric_devices"]
```

**Observed Behavior:**
```
Invalid network components provided for module 'sda_fabric_devices_workflow_manager': ['components_lists'].
Valid components are: ['fabric_devices']
```

**Expected Behavior:**
```
Invalid network components provided for module 'sda_fabric_devices_workflow_manager': ['components_lists'].
Valid components are: ['fabric_devices', 'component_list']
```

**Root Cause Analysis:**
`validate_component_specific_filters` built the valid-components hint using `list(network_elements.keys())`. Because `component_list` is extracted and handled separately before the component loop, it was never included in `network_elements` and never appeared in the error message.

**Fix Details:**
The valid-components list is now built as:
```python
valid_components = list(network_elements.keys()) + ["component_list"]
```

**Impact:**
Users who provide an invalid key under `component_specific_filters` now see `component_list` in the valid-components hint. The fix applies to all modules using `validate_component_specific_filters`.

---

## Testing Done
- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

**Test cases covered:**
-  All 10 unit tests pass (cases 2–10 covering `fabric_name` only, `device_ip`, single/multi `device_roles`, all filters combined, explicit `components_list`, and `file_mode: append`).
-  All 10 existing unit tests pass — each provides `fabric_name` and is unaffected by the new required-field check.
-  All existing unit tests pass unchanged — they all supply valid filter values.
-  All existing unit tests pass unchanged — the fix is additive with no impact on existing logic.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)
N/A
