### PR TITLE
Wireless Design Bug Fix

### DIFF
--- a/plugins/modules/wireless_design_playbook_config_generator.py
+++ b/plugins/modules/wireless_design_playbook_config_generator.py
@@ -435,6 +435,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         self.module_schema = self.get_workflow_elements_schema()
         self.module_name = "wireless_design_workflow_manager"
         self.country_code_map = None
+        self._api_response_to_module_attribute_map = None
 
     def validate_input(self):
         """
@@ -632,6 +633,162 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         )
 
         return schema
+
+    def _get_api_response_to_module_attribute_map(self):
+        """
+        Lazily initializes and returns API response to module attribute override map.
+
+        Returns:
+            dict: Mapping of API response attribute names to module attribute names.
+        """
+
+        if self._api_response_to_module_attribute_map is None:
+            self._api_response_to_module_attribute_map = {
+                "calledStationId": "called_station_id",
+                "peer2peerblocking": "peer2peer_blocking",
+                "passiveClient": "passive_client",
+                "predictionOptimization": "prediction_optimization",
+                "dualBandNeighborList": "dual_band_neighbor_list",
+                "radiusNacState": "radius_nac_state",
+                "dhcpRequired": "dhcp_required",
+                "dhcpServer": "dhcp_server",
+                "flexLocalAuth": "flex_local_auth",
+                "targetWakeupTime": "target_wakeup_time",
+                "downlinkOfdma": "downlink_ofdma",
+                "uplinkOfdma": "uplink_ofdma",
+                "downlinkMuMimo": "downlink_mu_mimo",
+                "uplinkMuMimo": "uplink_mu_mimo",
+                "dot11ax": "dot11ax",
+                "aironetIESupport": "aironet_ie_support",
+                "loadBalancing": "load_balancing",
+                "dtimPeriod5GHz": "dtim_period_5ghz",
+                "dtimPeriod24GHz": "dtim_period_24ghz",
+                "scanDeferTime": "scan_defer_time",
+                "maxClients": "max_clients",
+                "maxClientsPerRadio": "max_clients_per_radio",
+                "maxClientsPerAp": "max_clients_per_ap",
+                "wmmPolicy": "wmm_policy",
+                "multicastBuffer": "multicast_buffer",
+                "multicastBufferValue": "multicast_buffer_value",
+                "mediaStreamMulticastDirect": "media_stream_multicast_direct",
+                "muMimo11ac": "mu_mimo_11ac",
+                "wifiToCellularSteering": "wifi_to_cellular_steering",
+                "wifiAllianceAgileMultiband": "wifi_alliance_agile_multiband",
+                "fastlaneASR": "fastlane_asr",
+                "dot11vBSSMaxIdleProtected": "dot11v_bss_max_idle_protected",
+                "universalAPAdmin": "universal_ap_admin",
+                "opportunisticKeyCaching": "opportunistic_key_caching",
+                "ipSourceGuard": "ip_source_guard",
+                "dhcpOpt82RemoteIDSubOption": "dhcp_opt82_remote_id_sub_option",
+                "vlanCentralSwitching": "vlan_central_switching",
+                "callSnooping": "call_snooping",
+                "sendDisassociate": "send_disassociate",
+                "sent486Busy": "sent_486_busy",
+                "ipMacBinding": "ip_mac_binding",
+                "deferPriority0": "defer_priority_0",
+                "deferPriority1": "defer_priority_1",
+                "deferPriority2": "defer_priority_2",
+                "deferPriority3": "defer_priority_3",
+                "deferPriority4": "defer_priority_4",
+                "deferPriority5": "defer_priority_5",
+                "deferPriority6": "defer_priority_6",
+                "deferPriority7": "defer_priority_7",
+                "shareDataWithClient": "share_data_with_client",
+                "advertiseSupport": "advertise_support",
+                "advertisePCAnalyticsSupport": "advertise_pc_analytics_support",
+                "sendBeaconOnAssociation": "send_beacon_on_association",
+                "sendBeaconOnRoam": "send_beacon_on_roam",
+                "idleThreshold": "idle_threshold",
+                "fastTransitionReassociationTimeout": "fast_transition_reassociation_timeout",
+                "mDNSMode": "mdns_mode",
+                "radioBand": "radio_band",
+                "cleanAir": "clean_air",
+                "cleanAirDeviceReporting": "clean_air_device_reporting",
+                "persistentDevicePropagation": "persistent_device_propagation",
+                "description": "description",
+                "interferersFeatures": "interferers_features",
+                "bssColor": "bss_color",
+                "targetWaketimeBroadcast": "target_waketime_broadcast",
+                "nonSRGObssPdMaxThreshold": "non_srg_obss_pd_max_threshold",
+                "targetWakeUpTime11ax": "target_wakeup_time_11ax",
+                "obssPd": "obss_pd",
+                "multipleBssid": "multiple_bssid",
+                "dot11beStatus": "dot11be_status",
+                "eventDrivenRrmEnable": "event_driven_rrm_enable",
+                "eventDrivenRrmThresholdLevel": "event_driven_rrm_threshold_level",
+                "eventDrivenRrmCustomThresholdVal": "event_driven_rrm_custom_threshold_val",
+                "overlapIpEnable": "overlap_ip_enable",
+                "globalMulticastEnabled": "global_multicast_enabled",
+                "multicastIpv4Mode": "multicast_ipv4_mode",
+                "multicastIpv4Address": "multicast_ipv4_address",
+                "multicastIpv6Mode": "multicast_ipv6_mode",
+                "multicastIpv6Address": "multicast_ipv6_address",
+                "fraFreeze": "fra_freeze",
+                "fraStatus": "fra_status",
+                "fraInterval": "fra_interval",
+                "fraSensitivity": "fra_sensitivity",
+                "monitoringChannels": "monitoring_channels",
+                "neighborDiscoverType": "neighbor_discover_type",
+                "throughputThreshold": "throughput_threshold",
+                "coverageHoleDetection": "coverage_hole_detection",
+            }
+
+        return self._api_response_to_module_attribute_map
+
+    def _transform_attribute_name_to_snake_case(self, attribute):
+        """
+        Converts a camelCase/PascalCase attribute name to snake_case.
+
+        Args:
+            attribute (str): Attribute name to convert.
+
+        Returns:
+            str: Converted snake_case attribute name.
+        """
+
+        transformed_attribute = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", attribute)
+        transformed_attribute = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", transformed_attribute)
+        return transformed_attribute.lower()
+
+    def transform_feature_attributes_from_camel_case_to_snake_case(self, attribute):
+        """
+        Transforms a feature attribute from camelCase to snake_case format.
+
+        Args:
+            attribute (str): A feature attribute name in camelCase format.
+        Returns:
+            str: Transformed feature attribute name in snake_case format.
+        """
+
+        self.log(
+            "Starting feature attribute transformation from camelCase to snake_case for attribute: {0}"
+            .format(attribute),
+            "DEBUG",
+        )
+
+        if not isinstance(attribute, str):
+            self.log(
+                "Invalid attribute provided for transformation. Expected str, got: {0}".format(
+                    type(attribute).__name__
+                ),
+                "DEBUG",
+            )
+            return attribute
+
+        api_response_to_module_attribute_map = self._get_api_response_to_module_attribute_map()
+        transformed_attribute = api_response_to_module_attribute_map.get(attribute)
+
+        if transformed_attribute is None:
+            transformed_attribute = self._transform_attribute_name_to_snake_case(attribute)
+
+        self.log(
+            "Completed feature attribute transformation. Output: {0}".format(
+                transformed_attribute
+            ),
+            "DEBUG",
+        )
+
+        return transformed_attribute
 
     def wireless_ssid_temp_spec(self):
         """
@@ -1319,7 +1476,8 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "unlocked_attributes": {
                     "type": "list",
                     "elements": "str",
-                    "source_key": "unlockedAttributes"
+                    "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 }
             }
         )
@@ -1406,7 +1564,8 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "unlocked_attributes": {
                     "type": "list",
                     "elements": "str",
-                    "source_key": "unlockedAttributes"
+                    "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 }
             }
         )
@@ -1473,6 +1632,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1511,6 +1671,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1544,6 +1705,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1585,6 +1747,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1617,6 +1780,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1653,6 +1817,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -1693,12 +1858,13 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
         return rrm_fra_config_temp_spec
 
-    def wireless_rrm_rrm_general_config_temp_spec(self):
+    def wireless_rrm_general_config_temp_spec(self):
         """
         Constructs a temporary specification for wireless RRM general configuration,
         defining the structure and types of attributes used in the YAML file.
@@ -1729,6 +1895,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "type": "list",
                     "elements": "str",
                     "source_key": "unlockedAttributes",
+                    "transform": self.transform_feature_attributes_from_camel_case_to_snake_case
                 },
             }
         )
@@ -2526,7 +2693,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "api_function": "get_r_r_m_f_r_a_configuration_feature_template",
             },
             "RRM_GENERAL_CONFIGURATION": {
-                "temp_spec": self.wireless_rrm_rrm_general_config_temp_spec(),
+                "temp_spec": self.wireless_rrm_general_config_temp_spec(),
                 "attribute_name": "rrm_general_configuration",
                 "api_function": "get_r_r_m_general_configuration_feature_template",
             },


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
The unlocked_attributes field in the feature_template component currently are in camelCase format (e.g., radiusNacState, dhcpRequired, dhcpServer). However, the expected and documented format for these attributes is snake_case.

This change standardizes wireless feature template unlocked attribute names from API-style camelCase to module/playbook-style snake_case during playbook generation.

Added centralized attribute-name transformation in wireless_design_playbook_config_generator.py

Transformation now works in two steps:
1. Override mapping for known exceptions/special keys.
2. Generic fallback conversion from camelCase/PascalCase to snake_case for everything else.

Mapping initialization was optimized to lazy-load once, instead of rebuilding on every call.


Testing Done:
- [x] Manual testing
- [x] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

