### PR TITLE
multiple_ip_to_mac_addresses support

### DIFF
--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -210,6 +210,16 @@ options:
               segments.
             type: str
             required: false
+          multiple_ip_to_mac_addresses:
+            description: Indicates whether multiple IPs
+              can be associated with a single MAC address
+              for the layer2 fabric VLAN. By default,
+              it is set to false when associated with a
+              layer 3 virtual network and cannot be used
+              when not associated with a layer 3 virtual
+              network.
+            type: bool
+            default: false
           associated_layer3_virtual_network:
             description: Name of the layer3 virtual
               network associated with the layer2 fabric
@@ -1106,6 +1116,7 @@ class VirtualNetwork(DnacBase):
                 "resource_guard_enable": {"type": "bool"},
                 "flooding_address_assignment": {"type": "str"},
                 "flooding_address": {"type": "str"},
+                "multiple_ip_to_mac_addresses": {"type": "bool"},
             },
             "virtual_networks": {
                 "type": "list",
@@ -1752,6 +1763,8 @@ class VirtualNetwork(DnacBase):
                 - flooding_address_assignment (str, optional): How the flooding address is assigned
                   ("SHARED" or "CUSTOM").
                 - flooding_address (str, optional): The custom flooding address, if assignment is "CUSTOM".
+                - multiple_ip_to_mac_addresses (bool, optional): Whether multiple IPs can be associated
+                  with a single MAC address. Defaults to False.
             fabric_id_list (list): A list of fabric IDs where the VLAN configuration will be applied.
         Returns:
             list: A list of dictionaries, each containing the payload required to create or configure the VLAN
@@ -1793,6 +1806,9 @@ class VirtualNetwork(DnacBase):
             )
             vlan_payload["isResourceGuardEnabled"] = vlan.get(
                 "resource_guard_enable", False
+            )
+            vlan_payload["isMultipleIpToMacAddresses"] = vlan.get(
+                "multiple_ip_to_mac_addresses", False
             )
             vlan_payload["layer2FloodingAddressAssignment"] = vlan.get(
                 "flooding_address_assignment", "SHARED"
@@ -1901,6 +1917,8 @@ class VirtualNetwork(DnacBase):
                 - flooding_address_assignment (str): The assignment method for the flooding address
                   ('SHARED' or 'CUSTOM').
                 - flooding_address (str): The custom flooding IP address.
+                - multiple_ip_to_mac_addresses (bool): Indicates if multiple IPs can be associated
+                  with a single MAC address.
             current_vlan_config (dict): A dictionary representing the current VLAN configuration from Catalyst Center.
         Returns:
             bool: Returns `True` if the VLAN needs to be updated and `False` otherwise.
@@ -2024,6 +2042,22 @@ class VirtualNetwork(DnacBase):
                 )
                 return True
 
+            multiple_ip_to_mac = desired_vlan_config.get("multiple_ip_to_mac_addresses")
+            if (
+                multiple_ip_to_mac is not None
+                and multiple_ip_to_mac != current_vlan_config.get(
+                    "isMultipleIpToMacAddresses"
+                )
+            ):
+                self.log(
+                    "Multiple IP to MAC addresses setting needs update: desired='{0}', current='{1}'".format(
+                        multiple_ip_to_mac,
+                        current_vlan_config.get("isMultipleIpToMacAddresses"),
+                    ),
+                    "DEBUG",
+                )
+                return True
+
         self.log("No updates required for the fabric VLAN configuration.", "DEBUG")
 
         return False
@@ -2043,8 +2077,9 @@ class VirtualNetwork(DnacBase):
                 relevant identifiers and configuration details.
         Description:
             This function constructs a payload for updating a fabric VLAN in Cisco Catalyst Center. The resulting payload
-            is structured to include the VLAN ID, fabric ID, traffic type, wireless enablement status, and associated
-            Layer3 virtual network name and used to submit an update request to the Cisco Catalyst Center API.
+            is structured to include the VLAN ID, fabric ID, traffic type, wireless enablement status, multiple IP
+            to MAC addresses setting, and associated Layer3 virtual network name and used to submit an update request
+            to the Cisco Catalyst Center API.
         """
         self.log(
             "Constructing update payload for VLAN '{vlan_name}' on fabric '{fabric_id}'.".format(
@@ -2124,7 +2159,16 @@ class VirtualNetwork(DnacBase):
                     "layer2FloodingAddressAssignment"
                 )
 
+            multiple_ip_to_mac_addresses = new_vlan_config.get("multiple_ip_to_mac_addresses")
+            if multiple_ip_to_mac_addresses is None:
+                self.log(
+                    "Parameter 'multiple_ip_to_mac_addresses' not provided; using current value from Catalyst Center.",
+                    "DEBUG",
+                )
+                multiple_ip_to_mac_addresses = current_vlan_config.get("isMultipleIpToMacAddresses")
+
             vlan_update_payload["isResourceGuardEnabled"] = resource_guard_enable
+            vlan_update_payload["isMultipleIpToMacAddresses"] = multiple_ip_to_mac_addresses
             vlan_update_payload["layer2FloodingAddressAssignment"] = flooding_address_assignment
 
             if flooding_address_assignment == "CUSTOM":
@@ -4927,6 +4971,8 @@ class VirtualNetwork(DnacBase):
                 collected_add_vlan_payload.extend(
                     self.create_payload_for_fabric_vlan(vlan, fabric_id_list)
                 )
+
+        self.log("collected_add_vlan_payload: {0}".format(collected_add_vlan_payload), "DEBUG")
 
         if collected_add_vlan_payload:
             self.create_fabric_vlan(collected_add_vlan_payload).check_return_status()

--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -210,16 +210,6 @@ options:
               segments.
             type: str
             required: false
-          multiple_ip_to_mac_addresses:
-            description: Indicates whether multiple IPs
-              can be associated with a single MAC address
-              for the layer2 fabric VLAN. By default,
-              it is set to false when associated with a
-              layer 3 virtual network and cannot be used
-              when not associated with a layer 3 virtual
-              network.
-            type: bool
-            default: false
           associated_layer3_virtual_network:
             description: Name of the layer3 virtual
               network associated with the layer2 fabric
@@ -231,6 +221,16 @@ options:
               payload elements or none. And update
               of this field is not allowed.
             type: str
+          multiple_ip_to_mac_addresses:
+            description: Indicates whether multiple IPs
+              can be associated with a single MAC address
+              for the layer2 fabric VLAN. By default,
+              it is set to false when associated with a
+              layer 3 virtual network and cannot be used
+              when not associated with a layer 3 virtual
+              network.
+            type: bool
+            default: false
       virtual_networks:
         description: A list of virtual networks (VNs)
           configured within the SDA fabric. Each virtual
@@ -975,6 +975,33 @@ EXAMPLES = r"""
               site_name_hierarchy: "Global/India"
               fabric_type: "fabric_site"
             ip_pool_name: "IP_Pool_1"
+
+- name: Create fabric VLAN with multiple IP to MAC enabled
+  cisco.dnac.sda_fabric_virtual_networks_workflow_manager:
+    state: merged
+    config:
+      - fabric_vlan:
+          - vlan_name: "vlan_multi_ip"
+            vlan_id: 1944
+            traffic_type: "DATA"
+            associated_layer3_virtual_network: "L3_VN_1"
+            multiple_ip_to_mac_addresses: true
+            fabric_site_locations:
+              - site_name_hierarchy: "Global/India/Fabric_Test"
+                fabric_type: "fabric_site"
+
+- name: Create fabric VLAN without multiple_ip_to_mac_addresses (omitted)
+  cisco.dnac.sda_fabric_virtual_networks_workflow_manager:
+    state: merged
+    config:
+      - fabric_vlan:
+          - vlan_name: "vlan_default_multi_ip"
+            vlan_id: 1945
+            traffic_type: "DATA"
+            associated_layer3_virtual_network: "L3_VN_1"
+            fabric_site_locations:
+              - site_name_hierarchy: "Global/India/Fabric_Test"
+                fabric_type: "fabric_site"
 """
 RETURN = r"""
 dnac_response:
@@ -1807,9 +1834,12 @@ class VirtualNetwork(DnacBase):
             vlan_payload["isResourceGuardEnabled"] = vlan.get(
                 "resource_guard_enable", False
             )
-            vlan_payload["isMultipleIpToMacAddresses"] = vlan.get(
-                "multiple_ip_to_mac_addresses", False
-            )
+
+            if "multiple_ip_to_mac_addresses" in vlan:
+                vlan_payload["isMultipleIpToMacAddresses"] = vlan.get(
+                    "multiple_ip_to_mac_addresses"
+                )
+
             vlan_payload["layer2FloodingAddressAssignment"] = vlan.get(
                 "flooding_address_assignment", "SHARED"
             )
@@ -2043,20 +2073,19 @@ class VirtualNetwork(DnacBase):
                 return True
 
             multiple_ip_to_mac = desired_vlan_config.get("multiple_ip_to_mac_addresses")
-            if (
-                multiple_ip_to_mac is not None
-                and multiple_ip_to_mac != current_vlan_config.get(
-                    "isMultipleIpToMacAddresses"
+            if multiple_ip_to_mac is not None:
+                current_multiple_ip_to_mac = current_vlan_config.get(
+                    "isMultipleIpToMacAddresses", False
                 )
-            ):
-                self.log(
-                    "Multiple IP to MAC addresses setting needs update: desired='{0}', current='{1}'".format(
-                        multiple_ip_to_mac,
-                        current_vlan_config.get("isMultipleIpToMacAddresses"),
-                    ),
-                    "DEBUG",
-                )
-                return True
+                if multiple_ip_to_mac != current_multiple_ip_to_mac:
+                    self.log(
+                        "Multiple IP to MAC addresses setting needs update: desired='{0}', current='{1}'".format(
+                            multiple_ip_to_mac,
+                            current_multiple_ip_to_mac,
+                        ),
+                        "DEBUG",
+                    )
+                    return True
 
         self.log("No updates required for the fabric VLAN configuration.", "DEBUG")
 
@@ -4274,6 +4303,17 @@ class VirtualNetwork(DnacBase):
                 # Validate the correct fabric_type given in the playbook
                 self.validate_fabric_type(fabric_type).check_return_status()
                 self.log("Fabric type '{0}' is valid.".format(fabric_type), "INFO")
+
+            # Validate that multiple_ip_to_mac_addresses requires associated_layer3_virtual_network
+            if vlan.get("multiple_ip_to_mac_addresses") and not vlan.get("associated_layer3_virtual_network"):
+                self.msg = (
+                    "The parameter 'multiple_ip_to_mac_addresses' for VLAN '{0}' requires "
+                    "'associated_layer3_virtual_network' to be specified."
+                ).format(vlan_name)
+                self.set_operation_result(
+                    "failed", False, self.msg, "ERROR"
+                ).check_return_status()
+
             fabric_vlan_info.append(vlan)
 
         return fabric_vlan_info
@@ -4972,7 +5012,10 @@ class VirtualNetwork(DnacBase):
                     self.create_payload_for_fabric_vlan(vlan, fabric_id_list)
                 )
 
-        self.log("collected_add_vlan_payload: {0}".format(collected_add_vlan_payload), "DEBUG")
+        self.log(
+            "Collected fabric VLAN payload(s) for creation: {0}".format(collected_add_vlan_payload),
+            "DEBUG",
+        )
 
         if collected_add_vlan_payload:
             self.create_fabric_vlan(collected_add_vlan_payload).check_return_status()

--- a/tests/unit/modules/dnac/fixtures/sda_fabric_virtual_networks_workflow_manager.json
+++ b/tests/unit/modules/dnac/fixtures/sda_fabric_virtual_networks_workflow_manager.json
@@ -537,6 +537,87 @@
 
   "get_invalid_testbed_release":{
     "message": "The specified version '2.3.5.3' does not support the SDA fabric devices feature. Supported versions start from '2.3.7.6' onwards."
+  },
+
+  "playbook_config_create_fabric_vlan_with_multiple_ip_to_mac": [
+    {
+      "fabric_vlan": [
+        {
+          "vlan_name": "vlan_multi_ip",
+          "fabric_site_locations": [
+            {
+              "site_name_hierarchy": "Global/India/Fabric_Test",
+              "fabric_type": "fabric_site"
+            }
+          ],
+          "vlan_id": 1944,
+          "traffic_type": "DATA",
+          "fabric_enabled_wireless": false,
+          "multiple_ip_to_mac_addresses": true
+        }
+      ]
+    }
+  ],
+
+  "playbook_config_update_fabric_vlan_multiple_ip_to_mac": [
+    {
+      "fabric_vlan": [
+        {
+          "vlan_name": "vlan_multi_ip",
+          "fabric_site_locations": [
+            {
+              "site_name_hierarchy": "Global/India/Fabric_Test",
+              "fabric_type": "fabric_site"
+            }
+          ],
+          "vlan_id": 1944,
+          "traffic_type": "DATA",
+          "fabric_enabled_wireless": false,
+          "multiple_ip_to_mac_addresses": true
+        }
+      ]
+    }
+  ],
+
+  "get_empty_fabric_vlan_multi_ip_response": {
+    "response": [],
+    "version": "1.0"
+  },
+
+  "get_fabric_vlan_multi_ip_response": {
+    "response": [
+      {
+        "id": "aa629091-0592-440a-9dd8-e2274327b99c",
+        "fabricId": "879173be-e21f-472d-bc78-06407f9c5091",
+        "vlanName": "vlan_multi_ip",
+        "vlanId": 1944,
+        "trafficType": "DATA",
+        "isFabricEnabledWireless": false,
+        "isWirelessFloodingEnabled": false,
+        "isResourceGuardEnabled": false,
+        "isMultipleIpToMacAddresses": false,
+        "layer2FloodingAddressAssignment": "SHARED"
+      }
+    ],
+    "version": "1.0"
+  },
+
+  "get_fabric_vlan_multi_ip_created_response": {
+    "response": [
+      {
+        "id": "aa629091-0592-440a-9dd8-e2274327b99c",
+        "fabricId": "879173be-e21f-472d-bc78-06407f9c5091",
+        "vlanName": "vlan_multi_ip",
+        "vlanId": 1944,
+        "trafficType": "DATA",
+        "isFabricEnabledWireless": false,
+        "isWirelessFloodingEnabled": false,
+        "isResourceGuardEnabled": false,
+        "isMultipleIpToMacAddresses": true,
+        "layer2FloodingAddressAssignment": "SHARED"
+      }
+    ],
+    "version": "1.0"
   }
 
 }

--- a/tests/unit/modules/dnac/fixtures/sda_fabric_virtual_networks_workflow_manager.json
+++ b/tests/unit/modules/dnac/fixtures/sda_fabric_virtual_networks_workflow_manager.json
@@ -553,7 +553,8 @@
           "vlan_id": 1944,
           "traffic_type": "DATA",
           "fabric_enabled_wireless": false,
-          "multiple_ip_to_mac_addresses": true
+          "multiple_ip_to_mac_addresses": true,
+          "associated_layer3_virtual_network": "L3_VN_1"
         }
       ]
     }
@@ -573,7 +574,8 @@
           "vlan_id": 1944,
           "traffic_type": "DATA",
           "fabric_enabled_wireless": false,
-          "multiple_ip_to_mac_addresses": true
+          "multiple_ip_to_mac_addresses": true,
+          "associated_layer3_virtual_network": "L3_VN_1"
         }
       ]
     }

--- a/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
@@ -154,6 +154,16 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
                 self.test_data.get("response_get_task_status_by_id_success"),
             ]
 
+        elif "omit_multiple_ip_field" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_empty_fabric_vlan_multi_ip_response"),
+                self.test_data.get("get_site_details"),
+                self.test_data.get("get_fabric_site_details"),
+                self.test_data.get("get_empty_fabric_vlan_multi_ip_response"),
+                self.test_data.get("response_get_task_id_success"),
+                self.test_data.get("response_get_task_status_by_id_success"),
+            ]
+
         elif "create_virtual_network_with_verify" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_empty_virtual_network_response"),
@@ -846,5 +856,90 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
         result = self.execute_module(changed=False, failed=True)
         self.assertIn(
             "The specified version",
+            result.get('msg')
+        )
+
+    def test_sda_fabric_virtual_networks_workflow_manager_invalid_multiple_ip_to_mac_without_l3_vn(self):
+        """
+        Verify module fails when multiple_ip_to_mac_addresses is provided
+        without associated_layer3_virtual_network.
+        """
+        invalid_config = [
+            {
+                "fabric_vlan": [
+                    {
+                        "vlan_name": "vlan_multi_ip_invalid",
+                        "fabric_site_locations": [
+                            {
+                                "site_name_hierarchy": "Global/India/Fabric_Test",
+                                "fabric_type": "fabric_site",
+                            }
+                        ],
+                        "vlan_id": 1945,
+                        "traffic_type": "DATA",
+                        "fabric_enabled_wireless": False,
+                        "multiple_ip_to_mac_addresses": True,
+                    }
+                ]
+            }
+        ]
+
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="3.1.3.0",
+                dnac_log=True,
+                config_verify=False,
+                state="merged",
+                config=invalid_config,
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        self.assertIn(
+            "requires 'associated_layer3_virtual_network'",
+            result.get("msg"),
+        )
+
+    def test_sda_fabric_virtual_networks_workflow_manager_create_fabric_vlan_omit_multiple_ip_field(self):
+        """
+        Verify create flow does not force isMultipleIpToMacAddresses
+        when multiple_ip_to_mac_addresses is omitted.
+        """
+        config_without_multi_ip = [
+            {
+                "fabric_vlan": [
+                    {
+                        "vlan_name": "vlan_without_multi_ip",
+                        "fabric_site_locations": [
+                            {
+                                "site_name_hierarchy": "Global/India/Fabric_Test",
+                                "fabric_type": "fabric_site",
+                            }
+                        ],
+                        "vlan_id": 1946,
+                        "traffic_type": "DATA",
+                        "fabric_enabled_wireless": False,
+                    }
+                ]
+            }
+        ]
+
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="3.1.3.0",
+                dnac_log=True,
+                config_verify=False,
+                state="merged",
+                config=config_without_multi_ip,
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        self.assertIn(
+            "created successfully",
             result.get('msg')
         )

--- a/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
@@ -49,6 +49,8 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
     playbook_config_delete_absent_fabric_vlan = test_data.get("playbook_config_delete_absent_fabric_vlan")
     playbook_config_failed_anchored_virtual_network_creation = test_data.get("playbook_config_failed_anchored_virtual_network_creation")
     playbook_config_invalid_fabric_vlan_id = test_data.get("playbook_config_invalid_fabric_vlan_id")
+    playbook_config_create_fabric_vlan_with_multiple_ip_to_mac = test_data.get("playbook_config_create_fabric_vlan_with_multiple_ip_to_mac")
+    playbook_config_update_fabric_vlan_multiple_ip_to_mac = test_data.get("playbook_config_update_fabric_vlan_multiple_ip_to_mac")
 
     def setUp(self):
         super(TestDnacFabricSitesZonesWorkflow, self).setUp()
@@ -95,6 +97,16 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
                 self.test_data.get("get_fabric_vlan_response")
             ]
 
+        elif "update_fabric_vlan_multiple_ip_to_mac" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_fabric_vlan_multi_ip_response"),
+                self.test_data.get("get_site_details"),
+                self.test_data.get("get_fabric_site_details"),
+                self.test_data.get("get_fabric_vlan_multi_ip_response"),
+                self.test_data.get("response_get_task_id_success"),
+                self.test_data.get("response_get_task_status_by_id_success"),
+            ]
+
         elif "update_fabric_vlan" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_fabric_vlan_response"),
@@ -130,6 +142,16 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
         elif "invalid_fabric_vlan_id" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_invalid_fabric_vlan_id"),
+            ]
+
+        elif "create_fabric_vlan_with_multiple_ip_to_mac" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_empty_fabric_vlan_multi_ip_response"),
+                self.test_data.get("get_site_details"),
+                self.test_data.get("get_fabric_site_details"),
+                self.test_data.get("get_empty_fabric_vlan_multi_ip_response"),
+                self.test_data.get("response_get_task_id_success"),
+                self.test_data.get("response_get_task_status_by_id_success"),
             ]
 
         elif "create_virtual_network_with_verify" in self._testMethodName:
@@ -746,6 +768,58 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
         result = self.execute_module(changed=False, failed=True)
         self.assertIn(
             "Invalid vlan_id",
+            result.get('msg')
+        )
+
+    def test_sda_fabric_virtual_networks_workflow_manager_create_fabric_vlan_with_multiple_ip_to_mac(self):
+        """
+        Test case for creating a fabric VLAN with multiple_ip_to_mac_addresses enabled.
+
+        This test verifies that the module correctly creates a fabric VLAN with the
+        multiple_ip_to_mac_addresses parameter set to true on Catalyst Center >= 3.1.3.0.
+        """
+
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="3.1.3.0",
+                dnac_log=True,
+                config_verify=False,
+                state="merged",
+                config=self.playbook_config_create_fabric_vlan_with_multiple_ip_to_mac
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        self.assertIn(
+            "created successfully",
+            result.get('msg')
+        )
+
+    def test_sda_fabric_virtual_networks_workflow_manager_update_fabric_vlan_multiple_ip_to_mac(self):
+        """
+        Test case for updating a fabric VLAN to enable multiple_ip_to_mac_addresses.
+
+        This test verifies that the module detects a change in multiple_ip_to_mac_addresses
+        and triggers an update on Catalyst Center >= 3.1.3.0.
+        """
+
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_version="3.1.3.0",
+                dnac_log=True,
+                config_verify=False,
+                state="merged",
+                config=self.playbook_config_update_fabric_vlan_multiple_ip_to_mac
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        self.assertIn(
+            "updated successfully",
             result.get('msg')
         )
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Summary:
Previously: The module did not support the multiple_ip_to_mac_addresses parameter for fabric VLANs. This meant users could not control whether multiple IP addresses could be associated with a single MAC address at the Layer 2 fabric VLAN level.

What was added:

Documentation — A new multiple_ip_to_mac_addresses option was added under fabric_vlan suboptions, documented as a bool defaulting to false, applicable only when associated with a Layer 3 virtual network.

Validation schema — Added "multiple_ip_to_mac_addresses": {"type": "bool"} to the [temp_spec](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [validate_input()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Create payload (create_payload_for_fabric_vlan) — For Catalyst Center versions >= 3.1.3.0, the payload now includes:

Update detection (fabric_vlan_needs_update) — A comparison check was added so that if the desired multiple_ip_to_mac_addresses differs from the current isMultipleIpToMacAddresses value, the VLAN is flagged for update.

Update payload (update_payload_fabric_vlan) — The update payload now includes isMultipleIpToMacAddresses, falling back to the current config value if not specified in the playbook.



Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

