### PR TITLE
Add example for enable_bpu_guard param update

### DIFF
--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -175,7 +175,7 @@ options:
                   the network access and maintaining
                   security.
                 type: str
-              enable_bpu_guard:
+              enable_bpdu_guard:
                 description: A boolean setting that
                   enables or disables BPDU Guard. BPDU
                   Guard provides a security mechanism
@@ -485,7 +485,7 @@ EXAMPLES = r"""
               dot1x_fallback_timeout: 28
               wake_on_lan: false
               number_of_hosts: "Single"
-              enable_bpu_guard: false
+              enable_bpdu_guard: false
 
 - name: Deleting/removing fabric site from sda from
     Cisco Catalyst Center
@@ -599,7 +599,7 @@ class FabricSitesZones(DnacBase):
                     "dot1x_fallback_timeout": {"type": "int"},
                     "wake_on_lan": {"type": "bool"},
                     "number_of_hosts": {"type": "str"},
-                    "enable_bpu_guard": {"type": "bool"},
+                    "enable_bpdu_guard": {"type": "bool"},
                     "pre_auth_acl": {
                         "type": "dict",
                         "enabled": {"type": "bool"},
@@ -1414,7 +1414,7 @@ class FabricSitesZones(DnacBase):
                 is needed. Returns `False` if the settings match and no update is required.
         Description:
             This method compares the provided authentication profile settings (`auth_profile_dict`) with the current settings retrieved from
-            the Cisco Catalyst Center (`auth_profile_in_ccc`). It considers the possibility of an additional setting "enable_bpu_guard" if
+            the Cisco Catalyst Center (`auth_profile_in_ccc`). It considers the possibility of an additional setting "enable_bpdu_guard" if
             the current profile is "Closed Authentication".
             It iterates through a mapping of profile settings and checks if any of the settings require an update. If any discrepancies are
             found, the method returns `True`. If all settings match, it returns `False`.
@@ -1428,7 +1428,7 @@ class FabricSitesZones(DnacBase):
         }
         profile_name = auth_profile_in_ccc.get("authenticationProfileName")
         if profile_name == "Closed Authentication":
-            profile_key_mapping["enable_bpu_guard"] = "isBpduGuardEnabled"
+            profile_key_mapping["enable_bpdu_guard"] = "isBpduGuardEnabled"
 
         for key, ccc_key in profile_key_mapping.items():
             desired_value = auth_profile_dict.get(key)
@@ -1549,13 +1549,13 @@ class FabricSitesZones(DnacBase):
             )
 
         if profile_name == "Closed Authentication":
-            if auth_profile_dict.get("enable_bpu_guard") is None:
+            if auth_profile_dict.get("enable_bpdu_guard") is None:
                 authentications_params_dict["isBpduGuardEnabled"] = (
                     auth_profile_in_ccc.get("isBpduGuardEnabled", True)
                 )
             else:
                 authentications_params_dict["isBpduGuardEnabled"] = (
-                    auth_profile_dict.get("enable_bpu_guard")
+                    auth_profile_dict.get("enable_bpdu_guard")
                 )
 
         if (

--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -477,15 +477,15 @@ EXAMPLES = r"""
     state: merged
     config:
       - fabric_sites:
-        - site_name_hierarchy: "Global/Test_SDA/Bld1/Floor1"
-          fabric_type: "fabric_zone"
-          authentication_profile: "Closed Authentication"
-          update_authentication_profile:
-            authentication_order: "dot1x"
-            dot1x_fallback_timeout: 28
-            wake_on_lan: false
-            number_of_hosts: "Single"
-            enable_bpu_guard: false
+          - site_name_hierarchy: "Global/Test_SDA/Bld1/Floor1"
+            fabric_type: "fabric_zone"
+            authentication_profile: "Closed Authentication"
+            update_authentication_profile:
+              authentication_order: "dot1x"
+              dot1x_fallback_timeout: 28
+              wake_on_lan: false
+              number_of_hosts: "Single"
+              enable_bpu_guard: false
 
 - name: Deleting/removing fabric site from sda from
     Cisco Catalyst Center

--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -461,6 +461,32 @@ EXAMPLES = r"""
               dot1x_fallback_timeout: 28
               wake_on_lan: false
               number_of_hosts: "Single"
+
+- name: Update BPDU Guard in the Closed Authentication
+    profile template for a fabric zone.
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log_level: "{{dnac_log_level}}"
+    dnac_log: false
+    state: merged
+    config:
+      - fabric_sites:
+        - site_name_hierarchy: "Global/Test_SDA/Bld1/Floor1"
+          fabric_type: "fabric_zone"
+          authentication_profile: "Closed Authentication"
+          update_authentication_profile:
+            authentication_order: "dot1x"
+            dot1x_fallback_timeout: 28
+            wake_on_lan: false
+            number_of_hosts: "Single"
+            enable_bpu_guard: false
+
 - name: Deleting/removing fabric site from sda from
     Cisco Catalyst Center
   cisco.dnac.sda_fabric_sites_zones_workflow_manager:


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Enhancement Fix to add example for updating enable_bpu_guard param in sda fabric sites zones module.

Testing Done:
- [x] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

