### PR TITLE
Validate null filters

### DIFF
--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -1144,7 +1144,14 @@ class BrownFieldHelper:
         self.validate_config_filters_against_temp_spec(config_dict, temp_spec)
 
         component_specific_filters = config_dict.get("component_specific_filters")
-        if component_specific_filters is None:
+        if "component_specific_filters" in config_dict and component_specific_filters is None:
+            self.msg = (
+                "Invalid playbook config: 'component_specific_filters' cannot be null when provided. "
+                "Provide at least one filter or omit 'component_specific_filters'."
+            )
+            self.log(self.msg, "ERROR")
+            self.fail_and_exit(self.msg)
+        elif component_specific_filters is None:
             self.log(
                 "No 'component_specific_filters' provided in config; skipping validation.",
                 "DEBUG",
@@ -1159,7 +1166,14 @@ class BrownFieldHelper:
             self.fail_and_exit(self.msg)
 
         global_filters = config_dict.get("global_filters")
-        if global_filters is None:
+        if "global_filters" in config_dict and global_filters is None:
+            self.msg = (
+                "Invalid playbook config: 'global_filters' cannot be null when provided. "
+                "Provide at least one filter or omit 'global_filters'."
+            )
+            self.log(self.msg, "ERROR")
+            self.fail_and_exit(self.msg)
+        elif global_filters is None:
             self.log(
                 "No 'global_filters' provided in config; skipping validation.",
                 "DEBUG",

--- a/tests/unit/modules/dnac/fixtures/inventory_playbook_config_generator.json
+++ b/tests/unit/modules/dnac/fixtures/inventory_playbook_config_generator.json
@@ -60,6 +60,9 @@
     "playbook_config_empty_global_filters": {
         "global_filters": {}
     },
+    "playbook_config_null_global_filters": {
+        "global_filters": null
+    },
     "playbook_config_included_component_specific_filters": {
         "component_specific_filters": {}
     },

--- a/tests/unit/modules/dnac/test_inventory_playbook_config_generator.py
+++ b/tests/unit/modules/dnac/test_inventory_playbook_config_generator.py
@@ -49,6 +49,7 @@ class TestInventoryPlaybookConfigGenerator(TestDnacModule):
     playbook_config_unknown_filter_ignored = test_data.get("playbook_config_unknown_filter_ignored")
     playbook_config_no_matching_devices = test_data.get("playbook_config_no_matching_devices")
     playbook_config_empty_config = test_data.get("playbook_config_empty_config")
+    playbook_config_null_global_filters = test_data.get("playbook_config_null_global_filters")
 
     def setUp(self):
         super(TestInventoryPlaybookConfigGenerator, self).setUp()
@@ -248,8 +249,25 @@ class TestInventoryPlaybookConfigGenerator(TestDnacModule):
             config=self.playbook_config_empty_global_filters,
         ))
         result = self.execute_module(changed=False, failed=True)
-        self.assertIn("Invalid parameters in playbook config", str(result.get("msg", "")))
-        self.assertIn("Please provide at least one global filter", str(result.get("msg", "")))
+        self.assertIn("Invalid playbook config: 'global_filters' is empty.", str(result.get("msg", "")))
+        self.assertIn("Provide at least one filter or omit 'global_filters'.", str(result.get("msg", "")))
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.path.exists")
+    def test_null_global_filters(self, mock_exists, mock_file):
+        mock_exists.return_value = True
+        set_module_args(dict(
+            dnac_host="1.1.1.1",
+            dnac_username="dummy",
+            dnac_password="dummy",
+            dnac_version="2.3.7.9",
+            dnac_log=True,
+            state="gathered",
+            config=self.playbook_config_null_global_filters,
+        ))
+        result = self.execute_module(changed=False, failed=True)
+        self.assertIn("Invalid playbook config: 'global_filters' cannot be null when provided.", str(result.get("msg", "")))
+        self.assertIn("Provide at least one filter or omit 'global_filters'.", str(result.get("msg", "")))
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("os.path.exists")


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
When passing null as filters value, we are not validating. This causing module success with error message.
```
config:
    global_filters: null
```

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

