### PR TITLE
Wireless profile Config Generator - Overwrite status and message update

### DIFF
--- a/plugins/modules/network_profile_wireless_playbook_config_generator.py
+++ b/plugins/modules/network_profile_wireless_playbook_config_generator.py
@@ -2464,24 +2464,18 @@ class NetworkProfileWirelessPlaybookGenerator(NetworkProfileFunctions, BrownFiel
             )
         else:
             self.log(
-                f"YAML file write operation failed for file path: {file_path}. Check file "
-                f"permissions, disk space, and path validity. Configurations ready but "
-                f"not written: {len(final_list)}",
-                "ERROR"
+                f"YAML configuration file is already up-to-date at: {file_path}. "
+                f"No write operation performed.",
+                "INFO"
             )
 
             self.msg = {
-                "YAML config generation Task failed for module '{0}'.".format(
-                    self.module_name
-                ): {"file_path": file_path}
+                f"YAML configuration file already up-to-date for module '{self.module_name}'.  "
+                f"No changes required.": {
+                    "file_path": file_path
+                }
             }
-            self.set_operation_result("failed", True, self.msg, "ERROR")
-
-            self.log(
-                "YAML configuration generation failed due to file write error. "
-                "Operation result set to 'failed'. Returning instance with error state.",
-                "ERROR"
-            )
+            self.set_operation_result("ok", False, self.msg, "ERROR")
 
         return self
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Summary:
The network_profile_wireless_playbook_config_generator module successfully generates the YAML file during the first execution. However, when the same playbook is executed again with identical parameters and file_mode: overwrite, the module fails instead of recognizing that no changes are required.

Steps to Reproduce:
Execute the following playbook:

- name: Ex3 - Auto-discover all with explicit overwrite mode
      cisco.dnac.network_profile_wireless_playbook_config_generator:
        <<: *common_config
        state: gathered
        file_path: "network_profile_switch/auto_discover_all"
        file_mode: overwrite


Observed Behavior:
First run: File generated successfully
Second run: Fails with error

"msg": {
     "YAML config generation Task failed for module 'network_profile_wireless'.": {
         "file_path": "network_profile_switch/auto_discover_all"
     }
},


Expected Behavior:
Module should detect no changes in content
Return success with message:
YAML configuration file already up-to-date for module. No changes written.

Root Cause Analysis:
Technical explanation of the underlying cause, if known.

Workaround:
Any temporary solutions or mitigations available.

Fix Details:
Description of the fix or code changes made.

Impact:
Information on the scope and severity of the issue.

Additional Information:
Logs, configuration snippets, environment details, or references to related bugs.

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

