### PR TITLE
Handelled missing child sites case.

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -4790,6 +4790,13 @@ class FabricDevices(DnacBase):
             current_site = self.get_site(site_name).get("response", [])
 
             child_sites_response = self.get_site(site_name + "/.*")
+            if not child_sites_response:
+                self.log(
+                    f"No child sites found for site '{site_name}'.",
+                    "DEBUG",
+                )
+                continue
+
             child_sites = child_sites_response.get("response", [])
             self.log(
                 f"Found {len(child_sites)} child site(s) for site '{site_name}'.",


### PR DESCRIPTION
# Bug Fix: NoneType AttributeError in `process_scope_list()` for Sites with No Child Sites

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

### Summary
`get_site()` returns `None` when no child sites are found for a given site path. In `process_scope_list()`, the return value was used directly with `.get("response", [])` without a None check, causing an `AttributeError` crash.

### Steps to Reproduce
1. Configure a fabric device with `wireless_controller_settings` that includes `primary_managed_ap_locations` or `secondary_managed_ap_locations`.
2. Ensure that at least one of the listed AP location sites has **no child sites** in Catalyst Center.
3. Run the `sda_fabric_devices_workflow_manager` module.

Example playbook snippet:
```yaml
- fabric_devices:
    fabric_name: Global/USA/SAN_FRANCISCO
    device_config:
      - device_ip: 204.1.4.1
        device_roles:
          - BORDER_NODE
          - CONTROL_PLANE_NODE
          - WIRELESS_CONTROLLER_NODE
        wireless_controller_settings:
          enable: true
          primary_managed_ap_locations:
            - Global/USA/SAN_FRANCISCO/BLD_SF
            - Global/USA/SAN_FRANCISCO/BLD_SF/FLOOR1
            - Global/USA/SAN_FRANCISCO/BLD_SF/FLOOR2
          secondary_managed_ap_locations:
            - Global/USA/SAN_FRANCISCO/BLD_SF1
            - Global/USA/SAN_FRANCISCO/BLD_SF1/FLOOR1
            - Global/USA/SAN_FRANCISCO/BLD_SF1/FLOOR2
```

### Observed Behavior
```
line 4793, in process_scope_list
AttributeError: 'NoneType' object has no attribute 'get'
```
The module fails with an unhandled `AttributeError` when `get_site()` returns `None` for a site with no child sites.

### Expected Behavior
The module should handle sites with no child sites gracefully, skip them, and continue processing the remaining sites without error.

### Root Cause Analysis
`get_site()` returns `None` instead of an empty structure (e.g., `{"response": []}`) when no matching child sites are found. In `process_scope_list()` (line ~4793 of `sda_fabric_devices_workflow_manager.py`), the result was passed directly to `.get("response", [])` without a `None` guard, triggering the `AttributeError`.

The ideal fix would be to update `get_site()` to return `{"response": []}` instead of `None`, but since this function is shared across many modules, a targeted fix in `sda_fabric_devices_workflow_manager.py` is preferred to limit risk.

### Workaround
Ensure all sites listed under `primary_managed_ap_locations` and `secondary_managed_ap_locations` have at least one child site in Catalyst Center. This is not always practical or controllable.

### Fix Details
Added a `None` check on the return value of `get_site()` for the child sites query in `process_scope_list()`. If `None` is returned, a DEBUG log is emitted and the loop continues to the next site, preventing the crash.

```python
child_sites_response = self.get_site(site_name + "/.*")
if not child_sites_response:
    self.log(
        f"No child sites found for site '{site_name}'.",
        "DEBUG",
    )
    continue

child_sites = child_sites_response.get("response", [])
```

### Impact
- **Severity:** Medium — causes a module crash in a valid real-world configuration.
- **Scope:** Affects only `sda_fabric_devices_workflow_manager.py`; no other modules are modified.
- **Risk:** Minimal — the fix adds a guard and `continue` with no logic changes for the normal (non-None) path.

### Additional Information
- Affected file: `plugins/modules/sda_fabric_devices_workflow_manager.py`
- Affected function: `process_scope_list()` (~line 4790)
- Related function: `get_site()` — returns `None` for no-match results; a future improvement could change it to return `{"response": []}` consistently.

## Testing Done
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

**Test cases covered:**
- Site with no child sites in `primary_managed_ap_locations` — module now skips gracefully instead of crashing.
- Site with child sites — existing behavior unchanged.
- Mix of sites with and without child sites — all processed correctly.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)
N/A

## Notes to Reviewers
- The root cause lies in `get_site()` returning `None` for empty results. A more comprehensive fix (changing `get_site()` to always return `{"response": []}`) would be cleaner but carries cross-module risk and is deferred to a separate issue.
- This patch is intentionally minimal and scoped to `sda_fabric_devices_workflow_manager.py`.
