### PR TITLE
Add documentation for parallel execution of LAN Automation sessions 

### DIFF
--- a/plugins/modules/lan_automation_workflow_manager.py
+++ b/plugins/modules/lan_automation_workflow_manager.py
@@ -483,7 +483,66 @@ notes:
   - Links from different Port Channels cannot be mixed during update
     operations. Each physical link can belong to only one Port Channel
     at any given time.
+  - To run multiple LAN Automation sessions in parallel, use Ansible asynchronous
+    tasks within a single playbook. This allows multiple LAN session start tasks
+    to execute concurrently. Cisco Catalyst Center supports up to 5 concurrent
+    LAN Automation sessions.
+  - Parallel execution pattern:
+      1. Add `async: 3600`, `poll: 0`, and `register: <job_name>` on each LAN
+          Automation task.
+      2. Add a final `async_status` task that loops over all registered jobs and
+          waits until all of them finish.
+  - Example playbook structure for parallel execution:
+    - name: Start LAN session 1
+      cisco.dnac.lan_automation_workflow_manager:
+        dnac_host: "{{ dnac_host }}"
+        dnac_username: "{{ dnac_username }}"
+        dnac_password: "{{ dnac_password }}"
+        state: merged
+        config:
+          - lan_automation:
+              primary_device_management_ip_address: "204.1.1.1"
+              discovered_device_site_name_hierarchy: "Global/USA/SAN JOSE"
+              primary_device_interface_names:
+                - "HundredGigE1/0/2"
+              ip_pools:
+                - ip_pool_name: "underlay_sub_sj"
+                  ip_pool_role: "MAIN_POOL"
+              launch_and_wait: false
+      async: 3600
+      poll: 0
+      register: lan_job_1
 
+    - name: Start LAN session 2
+      cisco.dnac.lan_automation_workflow_manager:
+        dnac_host: "{{ dnac_host }}"
+        dnac_username: "{{ dnac_username }}"
+        dnac_password: "{{ dnac_password }}"
+        state: merged
+        config:
+          - lan_automation:
+              primary_device_management_ip_address: "204.1.1.2"
+              discovered_device_site_name_hierarchy: "Global/USA/SAN FRANCISCO"
+              primary_device_interface_names:
+                - "HundredGigE1/0/29"
+              ip_pools:
+                - ip_pool_name: "underlay_sub_sf"
+                  ip_pool_role: "MAIN_POOL"
+              launch_and_wait: false
+      async: 3600
+      poll: 0
+      register: lan_job_2
+
+    - name: Wait for all LAN sessions to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: lan_job_status
+      until: lan_job_status.finished
+      retries: 300
+      delay: 10
+      loop:
+        - "{{ lan_job_1 }}"
+        - "{{ lan_job_2 }}"
   - SDK Method used are
     lan_automation.LanAutomation.lan_automation_start_v2
     lan_automation.LanAutomation.lan_automation_stop

--- a/plugins/modules/lan_automation_workflow_manager.py
+++ b/plugins/modules/lan_automation_workflow_manager.py
@@ -613,64 +613,64 @@ EXAMPLES = r"""
   gather_facts: false
   connection: local
   tasks:
-      - name: Start LAN Automation session 1 asynchronously
-        cisco.dnac.lan_automation_workflow_manager:
-          dnac_host: "{{dnac_host}}"
-          dnac_username: "{{dnac_username}}"
-          dnac_password: "{{dnac_password}}"
-          dnac_verify: "{{dnac_verify}}"
-          dnac_port: "{{dnac_port}}"
-          dnac_version: "{{dnac_version}}"
-          dnac_debug: "{{dnac_debug}}"
-          state: merged
-          config:
-            - lan_automation:
-                primary_device_management_ip_address: "204.1.1.1"
-                discovered_device_site_name_hierarchy: "Global/USA/SAN JOSE"
-                primary_device_interface_names:
-                  - "HundredGigE1/0/2"
-                ip_pools:
-                  - ip_pool_name: "underlay_sub_sj"
-                    ip_pool_role: "MAIN_POOL"
-                launch_and_wait: false
-          async: 3600
-          poll: 0
-          register: lan_job_1
-
-      - name: Start LAN Automation session 2 asynchronously
-        cisco.dnac.lan_automation_workflow_manager:
-          dnac_host: "{{dnac_host}}"
-          dnac_username: "{{dnac_username}}"
-          dnac_password: "{{dnac_password}}"
-          dnac_verify: "{{dnac_verify}}"
-          dnac_port: "{{dnac_port}}"
-          dnac_version: "{{dnac_version}}"
-          dnac_debug: "{{dnac_debug}}"
-          state: merged
-          config:
-            - lan_automation:
-                primary_device_management_ip_address: "204.1.1.2"
-                discovered_device_site_name_hierarchy: "Global/USA/SAN FRANCISCO"
-                primary_device_interface_names:
-                  - "HundredGigE1/0/29"
-                ip_pools:
-                  - ip_pool_name: "underlay_sub_sf"
-                    ip_pool_role: "MAIN_POOL"
-                launch_and_wait: false
+    - name: Start LAN Automation session 1 asynchronously
+      cisco.dnac.lan_automation_workflow_manager:
+        dnac_host: "{{dnac_host}}"
+        dnac_username: "{{dnac_username}}"
+        dnac_password: "{{dnac_password}}"
+        dnac_verify: "{{dnac_verify}}"
+        dnac_port: "{{dnac_port}}"
+        dnac_version: "{{dnac_version}}"
+        dnac_debug: "{{dnac_debug}}"
+        state: merged
+        config:
+          - lan_automation:
+              primary_device_management_ip_address: "204.1.1.1"
+              discovered_device_site_name_hierarchy: "Global/USA/SAN JOSE"
+              primary_device_interface_names:
+                - "HundredGigE1/0/2"
+              ip_pools:
+                - ip_pool_name: "underlay_sub_sj"
+                  ip_pool_role: "MAIN_POOL"
+              launch_and_wait: false
         async: 3600
         poll: 0
-        register: lan_job_2
+        register: lan_job_1
 
-      - name: Wait for all asynchronous LAN Automation jobs
-        ansible.builtin.async_status:
-          jid: "{{ item.ansible_job_id }}"
-        register: lan_job_status
-        until: lan_job_status.finished
-        retries: 300
-        delay: 10
-        loop:
-            - "{{ lan_job_1 }}"
-            - "{{ lan_job_2 }}"
+    - name: Start LAN Automation session 2 asynchronously
+      cisco.dnac.lan_automation_workflow_manager:
+        dnac_host: "{{dnac_host}}"
+        dnac_username: "{{dnac_username}}"
+        dnac_password: "{{dnac_password}}"
+        dnac_verify: "{{dnac_verify}}"
+        dnac_port: "{{dnac_port}}"
+        dnac_version: "{{dnac_version}}"
+        dnac_debug: "{{dnac_debug}}"
+        state: merged
+        config:
+          - lan_automation:
+              primary_device_management_ip_address: "204.1.1.2"
+              discovered_device_site_name_hierarchy: "Global/USA/SAN FRANCISCO"
+              primary_device_interface_names:
+                - "HundredGigE1/0/29"
+              ip_pools:
+                - ip_pool_name: "underlay_sub_sf"
+                  ip_pool_role: "MAIN_POOL"
+              launch_and_wait: false
+      async: 3600
+      poll: 0
+      register: lan_job_2
+
+    - name: Wait for all asynchronous LAN Automation jobs
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: lan_job_status
+      until: lan_job_status.finished
+      retries: 300
+      delay: 10
+      loop:
+        - "{{ lan_job_1 }}"
+        - "{{ lan_job_2 }}"
 
 - name: Stop a LAN Automation session
   cisco.dnac.lan_automation_workflow_manager:

--- a/plugins/modules/lan_automation_workflow_manager.py
+++ b/plugins/modules/lan_automation_workflow_manager.py
@@ -487,62 +487,10 @@ notes:
     tasks within a single playbook. This allows multiple LAN session start tasks
     to execute concurrently. Cisco Catalyst Center supports up to 5 concurrent
     LAN Automation sessions.
-  - Parallel execution pattern:
-      1. Add `async: 3600`, `poll: 0`, and `register: <job_name>` on each LAN
-          Automation task.
-      2. Add a final `async_status` task that loops over all registered jobs and
-          waits until all of them finish.
-  - Example playbook structure for parallel execution:
-    - name: Start LAN session 1
-      cisco.dnac.lan_automation_workflow_manager:
-        dnac_host: "{{ dnac_host }}"
-        dnac_username: "{{ dnac_username }}"
-        dnac_password: "{{ dnac_password }}"
-        state: merged
-        config:
-          - lan_automation:
-              primary_device_management_ip_address: "204.1.1.1"
-              discovered_device_site_name_hierarchy: "Global/USA/SAN JOSE"
-              primary_device_interface_names:
-                - "HundredGigE1/0/2"
-              ip_pools:
-                - ip_pool_name: "underlay_sub_sj"
-                  ip_pool_role: "MAIN_POOL"
-              launch_and_wait: false
-      async: 3600
-      poll: 0
-      register: lan_job_1
-
-    - name: Start LAN session 2
-      cisco.dnac.lan_automation_workflow_manager:
-        dnac_host: "{{ dnac_host }}"
-        dnac_username: "{{ dnac_username }}"
-        dnac_password: "{{ dnac_password }}"
-        state: merged
-        config:
-          - lan_automation:
-              primary_device_management_ip_address: "204.1.1.2"
-              discovered_device_site_name_hierarchy: "Global/USA/SAN FRANCISCO"
-              primary_device_interface_names:
-                - "HundredGigE1/0/29"
-              ip_pools:
-                - ip_pool_name: "underlay_sub_sf"
-                  ip_pool_role: "MAIN_POOL"
-              launch_and_wait: false
-      async: 3600
-      poll: 0
-      register: lan_job_2
-
-    - name: Wait for all LAN sessions to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: lan_job_status
-      until: lan_job_status.finished
-      retries: 300
-      delay: 10
-      loop:
-        - "{{ lan_job_1 }}"
-        - "{{ lan_job_2 }}"
+  - For parallel execution, add async, poll, and register on each LAN
+    Automation task, then add a final async_status task that loops over the
+    registered jobs and waits for completion. Check the examples section for a
+    complete parallel execution playbook.
   - SDK Method used are
     lan_automation.LanAutomation.lan_automation_start_v2
     lan_automation.LanAutomation.lan_automation_stop
@@ -659,6 +607,70 @@ EXAMPLES = r"""
           device_serial_number_authorization:
             - "FJC27172JDW"
             - "FJC2721261A"
+
+- name: Start multiple LAN Automation sessions in parallel
+  hosts: dnac_servers
+  gather_facts: false
+  connection: local
+  tasks:
+      - name: Start LAN Automation session 1 asynchronously
+        cisco.dnac.lan_automation_workflow_manager:
+          dnac_host: "{{dnac_host}}"
+          dnac_username: "{{dnac_username}}"
+          dnac_password: "{{dnac_password}}"
+          dnac_verify: "{{dnac_verify}}"
+          dnac_port: "{{dnac_port}}"
+          dnac_version: "{{dnac_version}}"
+          dnac_debug: "{{dnac_debug}}"
+          state: merged
+          config:
+            - lan_automation:
+                primary_device_management_ip_address: "204.1.1.1"
+                discovered_device_site_name_hierarchy: "Global/USA/SAN JOSE"
+                primary_device_interface_names:
+                  - "HundredGigE1/0/2"
+                ip_pools:
+                  - ip_pool_name: "underlay_sub_sj"
+                    ip_pool_role: "MAIN_POOL"
+                launch_and_wait: false
+          async: 3600
+          poll: 0
+          register: lan_job_1
+
+      - name: Start LAN Automation session 2 asynchronously
+        cisco.dnac.lan_automation_workflow_manager:
+          dnac_host: "{{dnac_host}}"
+          dnac_username: "{{dnac_username}}"
+          dnac_password: "{{dnac_password}}"
+          dnac_verify: "{{dnac_verify}}"
+          dnac_port: "{{dnac_port}}"
+          dnac_version: "{{dnac_version}}"
+          dnac_debug: "{{dnac_debug}}"
+          state: merged
+          config:
+            - lan_automation:
+                primary_device_management_ip_address: "204.1.1.2"
+                discovered_device_site_name_hierarchy: "Global/USA/SAN FRANCISCO"
+                primary_device_interface_names:
+                  - "HundredGigE1/0/29"
+                ip_pools:
+                  - ip_pool_name: "underlay_sub_sf"
+                    ip_pool_role: "MAIN_POOL"
+                launch_and_wait: false
+        async: 3600
+        poll: 0
+        register: lan_job_2
+
+      - name: Wait for all asynchronous LAN Automation jobs
+        ansible.builtin.async_status:
+          jid: "{{ item.ansible_job_id }}"
+        register: lan_job_status
+        until: lan_job_status.finished
+        retries: 300
+        delay: 10
+        loop:
+            - "{{ lan_job_1 }}"
+            - "{{ lan_job_2 }}"
 
 - name: Stop a LAN Automation session
   cisco.dnac.lan_automation_workflow_manager:


### PR DESCRIPTION
Can be achieved by running playbooks in parallel using Ansible internal functionalities.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Description

Summary:
Catalyst Center supports up to 5 concurrent LAN Automation sessions, but users observed session execution in series when using a single playbook/task flow. This update clarifies how to achieve parallel session execution using Ansible capabilities, without changing module logic.

Steps to Reproduce:
1. Use LAN Automation tasks in one standard playbook flow without async handling.
2. Run the playbook. 
3. Observe tasks launching and completing one after another (serial behavior).

Observed Behavior:
LAN Automation tasks are triggered sequentially in common playbook usage, so sessions appear to run in series instead of parallel.

Expected Behavior:
Users should be able to start up to 5 LAN Automation sessions in parallel, matching Catalyst Center concurrency capability.

Root Cause Analysis:
This is not a module code defect. The module invocation pattern in playbooks is typically sequential unless users explicitly use Ansible parallel/asynchronous execution patterns. As a result, session starts can appear serialized.

Workaround:
1. Run multiple playbooks in parallel.
2. Or run multiple LAN Automation tasks asynchronously in one playbook using async + poll: 0 + async_status wait loop.

Fix Details:
Documentation-only enhancement in LAN Automation module notes/examples to explain and demonstrate parallel execution using Ansible asynchronous task handling. No runtime code path or business logic changes were made in the module.

Impact:
Low risk, documentation-only change. Improves user guidance and reduces confusion about parallel session capability.

Additional Information:
- Platform: Catalyst Center 2.3.7.6
- IaC version: 2.0
- No module behavior changes; only usage guidance was updated.

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered: [Mention test case IDs or brief points]
- Verified documentation accuracy against current Ansible async behavior.
- Verified guidance aligns with Catalyst Center limit of 5 concurrent LAN Automation sessions.
- Verified no functional code changes introduced.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using ansible-vault or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)
Not applicable.

## Notes to Reviewers
1. This change is intentionally documentation-only.
2. No code-level enhancement was made because parallel execution is already achievable via Ansible execution patterns.
3. Please review wording for clarity and consistency with existing module documentation style.
