### PR TITLE
fix(assurance_issue_playbook_config_generator): add strict key validation for sub filter entries

### DIFF
--- a/plugins/modules/assurance_issue_playbook_config_generator.py
+++ b/plugins/modules/assurance_issue_playbook_config_generator.py
@@ -364,6 +364,12 @@ class AssuranceIssuePlaybookGenerator(DnacBase, BrownFieldHelper):
 
         if config_provided:
             component_filters = valid_temp.get("component_specific_filters") or {}
+
+            # Validate that only known keys are present in component_specific_filters.
+            # Valid keys are the component block names from the schema plus 'components_list'.
+            valid_csf_keys = set(self.module_schema.get("issue_elements", {}).keys()) | {"components_list"}
+            self.validate_invalid_params(component_filters, valid_csf_keys)
+
             components_list = component_filters.get("components_list")
             has_components_list = isinstance(components_list, list) and len(components_list) > 0
             has_component_blocks = any(
@@ -426,6 +432,14 @@ class AssuranceIssuePlaybookGenerator(DnacBase, BrownFieldHelper):
                     ),
                     "DEBUG"
                 )
+                # Derive valid keys for each filter entry from the schema
+                valid_filter_keys = set(
+                    self.module_schema
+                    .get("issue_elements", {})
+                    .get("assurance_user_defined_issue_settings", {})
+                    .get("filters", {})
+                    .keys()
+                )
                 deduplicated_issue_filters = []
                 seen_filter_keys = set()
                 for filter_index, item in enumerate(issue_filters, start=1):
@@ -436,6 +450,9 @@ class AssuranceIssuePlaybookGenerator(DnacBase, BrownFieldHelper):
                         )
                         deduplicated_issue_filters.append(item)
                         continue
+
+                    # Reject any unrecognized keys in the filter entry
+                    self.validate_invalid_params(item, valid_filter_keys)
 
                     filter_key = (
                         item.get("name"),


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Problem
When users passed misspelled or undefined keys inside component_specific_filters or its sub-option assurance_user_defined_issue_settings, the module silently ignored those invalid keys and continued execution. This resulted in empty or unexpected outputs for the intended filters, without raising any error, making debugging difficult.

Fix
Added strict input validation in validate_input using the existing validate_invalid_params utility from brownfield_helper.py:

Top-level validation
component_specific_filters keys are now validated against:
Component names defined in module_schema["issue_elements"]
components_list
→ Any unknown key now fails immediately with a clear error.
Nested validation
Each entry under assurance_user_defined_issue_settings is validated against allowed filter keys:
name
is_enabled
→ Invalid keys are rejected before deduplication or API execution.
Dynamic schema alignment
All valid key sets are derived dynamically from self.module_schema, ensuring validation automatically stays consistent with future schema changes.
Behavior After Fix
Invalid or misspelled keys now result in immediate failure with clear error messages.
Prevents silent failures and improves debuggability.
Ensures only valid, schema-compliant inputs are processed.

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

