### PR TITLE
Wireless Design CG Bug Fix

### DIFF
--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -2690,6 +2690,39 @@ class BrownFieldHelper:
         self.status = "success"
         return self
 
+    def should_use_string_pagination_params(self, fixed_sdk_version):
+        """
+        Determine if pagination params should be sent as strings for SDK compatibility.
+
+        Args:
+            fixed_sdk_version (str): SDK version where the pagination conversion fix is
+                available. Example: "2.11.2".
+
+        Returns:
+            bool: True when installed dnacentersdk version is lower than
+                fixed_sdk_version, else False.
+
+        Note:
+            Certain dnacentersdk versions required string values for pagination
+            params like offset/limit in some wrappers. Newer versions normalize
+            these values safely. Passing the target version keeps this helper
+            reusable for different compatibility thresholds.
+
+            This helper intentionally reuses self.compare_dnac_versions for SDK
+            version comparison as well. Both DNAC and dnacentersdk versions are
+            represented as dotted numeric segments (for example, "2.11.2"), so
+            the same comparison logic applies consistently.
+        """
+        if not getattr(self, "dnacentersdk_version", None):
+            self.dnacentersdk_version = self.get_dnacentersdk_version()
+
+        return (
+            self.compare_dnac_versions(
+                self.dnacentersdk_version, fixed_sdk_version
+            )
+            < 0
+        )
+
     def execute_get_with_pagination(
         self,
         api_family,

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -12,11 +12,11 @@ try:
 except ImportError:
     HAS_FERNET = False
 try:
+    import dnacentersdk
     from dnacentersdk import api, exceptions
+    DNAC_SDK_IS_INSTALLED = True
 except ImportError:
     DNAC_SDK_IS_INSTALLED = False
-else:
-    DNAC_SDK_IS_INSTALLED = True
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common import validation
 from abc import ABCMeta, abstractmethod
@@ -153,6 +153,10 @@ class DnacBase():
 
         # Versions are equal
         return 0
+
+    def get_dnacentersdk_version(self):
+        """Returns the installed dnacentersdk version string."""
+        return self.dnac.dnacentersdk_version
 
     def get_safe_log_config(self, config_dict):
         """
@@ -2997,6 +3001,7 @@ class DNACSDK(object):
                 verify=params.get("dnac_verify"),
                 debug=params.get("dnac_debug"),
             )
+            self.dnacentersdk_version = dnacentersdk.__version__
             if params.get("dnac_debug") and LOGGING_IN_STANDARD:
                 self.logger.addHandler(logging.StreamHandler())
         else:

--- a/plugins/modules/wireless_design_playbook_config_generator.py
+++ b/plugins/modules/wireless_design_playbook_config_generator.py
@@ -3395,7 +3395,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_access_point_profile_details = self.execute_get_with_pagination(
-                    api_family, api_function, params, use_strings=True
+                    api_family, api_function, params
                 )
 
                 if wireless_access_point_profile_details:
@@ -3423,7 +3423,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless access point profiles from Catalyst Center", "DEBUG")
 
             wireless_access_point_profile_details = self.execute_get_with_pagination(
-                api_family, api_function, params, use_strings=True
+                api_family, api_function, params
             )
 
             if wireless_access_point_profile_details:
@@ -3656,7 +3656,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_anchor_group_details = self.execute_get_with_pagination(
-                    api_family, api_function, params, use_strings=True
+                    api_family, api_function, params
                 )
 
                 if "anchor_group_name" in filter_param:
@@ -3685,7 +3685,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless anchor groups from Catalyst Center", "DEBUG")
 
             wireless_anchor_group_details = self.execute_get_with_pagination(
-                api_family, api_function, params, use_strings=True
+                api_family, api_function, params
             )
 
             if wireless_anchor_group_details:

--- a/plugins/modules/wireless_design_playbook_config_generator.py
+++ b/plugins/modules/wireless_design_playbook_config_generator.py
@@ -434,6 +434,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         super().__init__(module)
         self.module_schema = self.get_workflow_elements_schema()
         self.module_name = "wireless_design_workflow_manager"
+        self.dnacentersdk_version = self.get_dnacentersdk_version()
         self.country_code_map = None
         self._api_response_to_module_attribute_map = None
 
@@ -3369,6 +3370,11 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "DEBUG"
         )
 
+        # SDK versions below 2.11.2 can require offset/limit as strings in paginated calls.
+        use_strings_for_pagination = self.should_use_string_pagination_params(
+            "2.11.2"
+        )
+
         params = {}
         if component_specific_filters:
             self.log(
@@ -3395,7 +3401,10 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_access_point_profile_details = self.execute_get_with_pagination(
-                    api_family, api_function, params
+                    api_family,
+                    api_function,
+                    params,
+                    use_strings=use_strings_for_pagination,
                 )
 
                 if wireless_access_point_profile_details:
@@ -3423,7 +3432,10 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless access point profiles from Catalyst Center", "DEBUG")
 
             wireless_access_point_profile_details = self.execute_get_with_pagination(
-                api_family, api_function, params
+                api_family,
+                api_function,
+                params,
+                use_strings=use_strings_for_pagination,
             )
 
             if wireless_access_point_profile_details:
@@ -3633,6 +3645,11 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "DEBUG"
         )
 
+        # SDK versions below 2.11.2 can require offset/limit as strings in paginated calls.
+        use_strings_for_pagination = self.should_use_string_pagination_params(
+            "2.11.2"
+        )
+
         params = {}
         if component_specific_filters:
             self.log(
@@ -3656,7 +3673,10 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_anchor_group_details = self.execute_get_with_pagination(
-                    api_family, api_function, params
+                    api_family,
+                    api_function,
+                    params,
+                    use_strings=use_strings_for_pagination,
                 )
 
                 if "anchor_group_name" in filter_param:
@@ -3685,7 +3705,10 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless anchor groups from Catalyst Center", "DEBUG")
 
             wireless_anchor_group_details = self.execute_get_with_pagination(
-                api_family, api_function, params
+                api_family,
+                api_function,
+                params,
+                use_strings=use_strings_for_pagination,
             )
 
             if wireless_anchor_group_details:


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
The wireless_design_playbook_config_generator module fails when retrieving AP profiles and anchor groups with the following error:
```
  msg: 'An error occurred while retrieving data using family ''wireless'', function ''get_ap_profiles''. Error: We were expecting to receive an instance of one of the following types: ''int''or ''None''; but instead we received 500 which is a ''str''.'
```

The SDK recently `fixed: updating parameter types for limit and offset to int in multiple modules.`
Earlier it was using str type for limit and offset params. After raising issue with SDK team, the team fixed this issue in latest SDK Version: (dnacentersdk)2.11.2

## Proposed Fix:
By default we implemented execute_with_pagination function in brownfield_helper.py file to pass integer arguments for limit and offset fields. For handling string type, we pass use_strings argument as true to the function which converts limit and offset fields to string.

The following change adds backward compatibility for dnacentersdk pagination behavior in wireless design playbook config generation, while keeping the logic reusable and centralized.
* Exposed installed dnacentersdk version through shared DNAC utilities (dnac.py)
* Added a reusable helper that decides when string pagination params are needed based on a caller-provided SDK fix version. (brownfield_helper.py)
* Updated wireless design retrieval paths to apply this compatibility logic for wireless access point profiles and wireless anchor groups.
* Added in-code comments and helper documentation for readability and maintainability.

For environments with dnacentersdk < 2.11.2, paginated calls now send offset and limit as strings where required.
For newer SDK versions, existing integer pagination behavior remains unchanged.

Verified the fix by using dnacentersdk version 2.11.1 and 2.11.2
Before fix, dnacentersdk version 2.11.1 passes and 2.11.2 fails.
After fix, both versions got passed.

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

