### PR TITLE
Remove use_strings pagination mode and enforce integer offset/limit across wireless and helper flows

### DIFF
--- a/plugins/module_utils/brownfield_helper.py
+++ b/plugins/module_utils/brownfield_helper.py
@@ -2697,7 +2697,6 @@ class BrownFieldHelper:
         params=None,
         offset=1,
         limit=500,
-        use_strings=False,
     ):
         """
         Executes a paginated GET request using the specified API family, function, and parameters.
@@ -2707,7 +2706,6 @@ class BrownFieldHelper:
             params (dict): Parameters for filtering the data.
             offset (int, optional): Starting offset for pagination. Defaults to 1.
             limit (int, optional): Maximum number of records to retrieve per page. Defaults to 500.
-            use_strings (bool, optional): Whether to use string values for offset and limit. Defaults to False.
         Returns:
             list: A list of dictionaries containing the retrieved data based on the filtering parameters.
         """
@@ -2724,8 +2722,8 @@ class BrownFieldHelper:
             updated_params = params.copy()
             updated_params.update(
                 {
-                    "offset": str(current_offset) if use_strings else current_offset,
-                    "limit": str(current_limit) if use_strings else current_limit,
+                    "offset": current_offset,
+                    "limit": current_limit,
                 }
             )
             return updated_params
@@ -2746,8 +2744,8 @@ class BrownFieldHelper:
             current_limit = limit
 
             self.log(
-                "Pagination settings - offset: {0}, limit: {1}, use_strings: {2}".format(
-                    current_offset, current_limit, use_strings
+                "Pagination settings - offset: {0}, limit: {1}".format(
+                    current_offset, current_limit
                 ),
                 "DEBUG",
             )

--- a/plugins/modules/wireless_design_playbook_config_generator.py
+++ b/plugins/modules/wireless_design_playbook_config_generator.py
@@ -200,8 +200,8 @@ options:
                 type: str
 
 requirements:
-- dnacentersdk >= 2.3.7.9
-- python >= 3.9
+- dnacentersdk >= 2.11.2
+- python >= 3.12
 notes:
 - Cisco Catalyst Center >= 2.3.7.9
 - |-
@@ -3395,7 +3395,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_access_point_profile_details = self.execute_get_with_pagination(
-                    api_family, api_function, params, use_strings=True
+                    api_family, api_function, params
                 )
 
                 if wireless_access_point_profile_details:
@@ -3423,7 +3423,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless access point profiles from Catalyst Center", "DEBUG")
 
             wireless_access_point_profile_details = self.execute_get_with_pagination(
-                api_family, api_function, params, use_strings=True
+                api_family, api_function, params
             )
 
             if wireless_access_point_profile_details:
@@ -3656,7 +3656,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "DEBUG"
                 )
                 wireless_anchor_group_details = self.execute_get_with_pagination(
-                    api_family, api_function, params, use_strings=True
+                    api_family, api_function, params
                 )
 
                 if "anchor_group_name" in filter_param:
@@ -3685,7 +3685,7 @@ class WirelessDesignPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             self.log("Fetching all wireless anchor groups from Catalyst Center", "DEBUG")
 
             wireless_anchor_group_details = self.execute_get_with_pagination(
-                api_family, api_function, params, use_strings=True
+                api_family, api_function, params
             )
 
             if wireless_anchor_group_details:

--- a/plugins/modules/wireless_design_workflow_manager.py
+++ b/plugins/modules/wireless_design_workflow_manager.py
@@ -4191,8 +4191,8 @@ options:
             required: false
 
 requirements:
-  - dnacentersdk >= 2.10.3
-  - python >= 3.9
+  - dnacentersdk >= 2.11.2
+  - python >= 3.12
 notes:
   - SDK Methods used are - sites.Sites.get_site - site_design.SiteDesigns.get_sites
     - wirelesss.Wireless.create_ssid - wirelesss.Wireless.update_ssid
@@ -19576,11 +19576,11 @@ class WirelessDesign(DnacBase):
         Returns:
             list: A list of dictionaries containing the retrieved data based on the filtering parameters.
         """
-        def update_params(offset, limit, use_strings=False):
+        def update_params(offset, limit):
             """Update the params dictionary with pagination info."""
             params.update({
-                "offset": str(offset) if use_strings else offset,
-                "limit": str(limit) if use_strings else limit
+            "offset": offset,
+            "limit": limit
             })
 
         try:
@@ -19588,18 +19588,17 @@ class WirelessDesign(DnacBase):
             offset = 1
             limit = 500
             results = []
-            use_strings = api_function in {"get_ap_profiles", "get_anchor_groups"}
 
             # Start the loop for paginated API calls
             while True:
                 # Update parameters for pagination
-                update_params(offset, limit, use_strings)
+                update_params(offset, limit)
 
                 try:
                     # Execute the API call
                     self.log(
-                        "Attempting API call with {0} offset and limit for family '{1}', function '{2}': {3}".format(
-                            "string" if use_strings else "integer", api_family, api_function, params
+                        "Attempting API call with integer offset and limit for family '{0}', function '{1}': {2}".format(
+                            api_family, api_function, params
                         ),
                         "INFO"
                     )
@@ -19613,23 +19612,11 @@ class WirelessDesign(DnacBase):
                     )
 
                 except Exception as e:
-                    # Retry with integer offset/limit for specific cases
-                    if api_function == "get_ap_profiles" and use_strings:
-                        self.log(
-                            "API call failed with string offset and limit. Retrying with integer values. Error: {0}".format(
-                                str(e)
-                            ),
-                            "WARNING",
-                        )
-                        use_strings = False
-                        continue
-
-                    else:
-                        self.msg = (
-                            "An error occurred while retrieving data using family '{0}', function '{1}'. "
-                            "Details using API call. Error: {2}".format(api_family, api_function, str(e))
-                        )
-                        self.fail_and_exit(self.msg)
+                    self.msg = (
+                        "An error occurred while retrieving data using family '{0}', function '{1}'. "
+                        "Details using API call. Error: {2}".format(api_family, api_function, str(e))
+                    )
+                    self.fail_and_exit(self.msg)
 
                 self.log(
                     "Response received from API call for family '{0}', function '{1}': {2}".format(

--- a/plugins/modules/wireless_design_workflow_manager.py
+++ b/plugins/modules/wireless_design_workflow_manager.py
@@ -19579,8 +19579,8 @@ class WirelessDesign(DnacBase):
         def update_params(offset, limit):
             """Update the params dictionary with pagination info."""
             params.update({
-            "offset": offset,
-            "limit": limit
+                "offset": offset,
+                "limit": limit
             })
 
         try:


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
The wireless_design_playbook_config_generator module fails when retrieving AP profiles and anchor groups with the following error:

```
 msg: 'An error occurred while retrieving data using family ''wireless'', function ''get_ap_profiles''. Error: We were expecting to receive an instance of one of the following types: ''int''or ''None''; but instead we received 500 which is a ''str''.'
 ```

The SDK recently fixed: updating parameter types for limit and offset to int in multiple modules.
Earlier it was using str type for limit and offset params. After raising issue with SDK team, the team fixed this issue in latest SDK Version: (dnacentersdk)2.11.2

## Fix
* Removed use_strings support from shared pagination helper and related call paths.
* Updated Wireless Design pagination flow to use integer offset and limit only.
* Removed fallback/retry logic that attempted string-based pagination.
* Updated module documentation requirements to reflect the minimum dependency versions for this fix:
    * dnacentersdk >= 2.11.2
    * python >= 3.12

This SDK fix is available with SDK 2.11.2 behavior, which requires Python 3.12 in this workflow.

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

