### PR TITLE
Enforce strict input parameter validation in multicast and tags playbook config generator

### DIFF
--- a/plugins/modules/sda_fabric_multicast_playbook_config_generator.py
+++ b/plugins/modules/sda_fabric_multicast_playbook_config_generator.py
@@ -679,7 +679,7 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             dict: A dictionary containing the workflow filters schema with the following structure:
                 - network_elements (dict): Contains configuration for different network element types
                     - fabric_multicast (dict): Configuration for fabric multicast operations
-                        - filters (list): List of filter parameters (fabric_name, layer3_virtual_network)
+                        - filters (dict): Dict of filter parameters with type/required specs (fabric_name, layer3_virtual_network)
                         - reverse_mapping_function (method): Function to map fabric multicast specifications
                         - api_function (str): API function name for retrieving fabric multicast
                         - api_family (str): API family identifier
@@ -697,7 +697,10 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         schema = {
             "network_elements": {
                 "fabric_multicast": {
-                    "filters": ["fabric_name", "layer3_virtual_network"],
+                    "filters": {
+                        "fabric_name": {"type": "str", "required": False},
+                        "layer3_virtual_network": {"type": "str", "required": False},
+                    },
                     "reverse_mapping_function": self.fabric_multicast_temp_spec,
                     "api_function": "get_multicast_virtual_networks",
                     "api_family": "sda",
@@ -727,6 +730,8 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         Returns:
             dict: Dictionary with 'fabric_multicast' key containing list of processed multicast
                   configurations modified according to fabric_multicast_temp_spec template.
+            None: If no multicast configurations are found for processing, or if transformation
+                produces no valid output.
 
         Description:
             Fetches fabric multicast details using component-specific filters or retrieves all
@@ -904,10 +909,10 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
 
         if not all_multicast_configs:
             self.log(
-                "No multicast configurations to process. Returning empty fabric_multicast list.",
+                "No multicast configurations to process. Returning None.",
                 "WARNING",
             )
-            return {"fabric_multicast": []}
+            return None
 
         # Modify multicast details using temp_spec
         self.log(
@@ -923,6 +928,13 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         multicast_details = self.modify_parameters(
             fabric_multicast_temp_spec, all_multicast_configs
         )
+
+        if not multicast_details:
+            self.log(
+                "No multicast configurations were transformed successfully, returning None",
+                "WARNING",
+            )
+            return None
 
         self.log(
             f"Successfully transformed {len(multicast_details)} multicast configuration(s)",
@@ -1472,6 +1484,8 @@ class SdaFabricMulticastPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         """
 
         self.log(f"Creating Parameters for API Calls with state: {state}", "INFO")
+
+        self.validate_params(config)
 
         want = {}
 

--- a/plugins/modules/tags_playbook_config_generator.py
+++ b/plugins/modules/tags_playbook_config_generator.py
@@ -833,13 +833,13 @@ class TagsPlaybookGenerator(DnacBase, BrownFieldHelper):
             dict: A dictionary containing the workflow filters schema with the following structure:
                 - network_elements (dict): Contains configuration for different network element types
                     - tags (dict): Configuration for tag-related operations
-                        - filters (list): List of filter parameters (tag_name, tag_id)
+                        - filters (dict): Dict of filter parameters with type/required specs (tag_name, tag_id)
                         - reverse_mapping_function (method): Function to map tag specifications
                         - api_function (str): API function name for retrieving tags
                         - api_family (str): API family identifier
                         - get_function_name (method): Method to get tag configuration
                     - tag_memberships (dict): Configuration for tag membership operations
-                        - filters (list): List of filter parameters (tag_name, tag_id)
+                        - filters (dict): Dict of filter parameters with type/required/choices specs (tag_name, tag_id, device_identifier)
                         - reverse_mapping_function (method): Function to map tag membership specs
                         - api_function (str): API function name for retrieving tag members
                         - api_family (str): API family identifier
@@ -855,14 +855,31 @@ class TagsPlaybookGenerator(DnacBase, BrownFieldHelper):
         schema = {
             "network_elements": {
                 "tags": {
-                    "filters": ["tag_name", "tag_id"],
+                    "filters": {
+                        "tag_name": {"type": "str", "required": False},
+                        "tag_id": {"type": "str", "required": False},
+                    },
                     "reverse_mapping_function": self.tag_temp_spec,
                     "api_function": "get_tag",
                     "api_family": "tag",
                     "get_function_name": self.get_tags_configuration,
                 },
                 "tag_memberships": {
-                    "filters": ["tag_name", "tag_id", "device_identifier"],
+                    "filters": {
+                        "tag_name": {"type": "str", "required": False},
+                        "tag_id": {"type": "str", "required": False},
+                        "device_identifier": {
+                            "type": "str",
+                            "required": False,
+                            "default": "serial_number",
+                            "choices": [
+                                "hostname",
+                                "serial_number",
+                                "mac_address",
+                                "ip_address",
+                            ],
+                        },
+                    },
                     "reverse_mapping_function": self.tag_memberships_temp_spec,
                     "api_function": "get_tag_members_by_id",
                     "api_family": "tag",


### PR DESCRIPTION
# multicast and tags modules

## Title
Enforce strict input parameter validation in multicast and tags playbook config generators

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Description

Summary:
Enabled strict validation for component-specific input filters in multicast and tags playbook config generation.

Steps to Reproduce:
1. Run multicast playbook config generator with invalid filter type/value.
2. Observe behavior before fix vs after fix.

Observed Behavior:
Invalid or unsupported filter inputs were not consistently validated in the multicast and tags flows.

Expected Behavior:
Invalid filter inputs should fail validation early with clear logs/messages.

Root Cause Analysis:
Validation flow and filter schema definitions in multicast and tags modules were not fully aligned with BrownFieldHelper strict component filter validation path and return handling/documentation consistency.

Workaround:
Avoid invalid filter values manually and use only documented filter keys/types.

Fix Details:
- Added strict validation trigger in multicast request preparation path.
- Updated workflow filter schemas in multicast and tags modules to typed filter definitions for strict validation.
- Added early return handling when no multicast data is available/transformed.
- Updated related docstrings to match actual return behavior.

Impact:
Low risk, localized to multicast and tags config generator behavior.
Improves reliability and prevents invalid input from silently proceeding.

Additional Information:
This change enforces strict validations on input parameters.

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered:
- Invalid filter key rejected
- Invalid filter type rejected
- Unsupported filter choice rejected
- Empty/no data path returns None correctly
- tags filters validate typed schema and allowed choices correctly

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (for example, using ansible-vault or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)
Not applicable.

## Notes to Reviewers
Please focus review on strict filter validation behavior in both modules, and no-data/transform-none return paths in multicast module.
