### PR TITLE
New design changes for device_credential_playbook_config_generator

### DIFF
--- a/playbooks/device_credential_playbook_config_generator.yml
+++ b/playbooks/device_credential_playbook_config_generator.yml
@@ -53,12 +53,18 @@
           component_specific_filters:
             components_list: ["global_credential_details"]
             global_credential_details:
-              cli_credential:
-                - description: test
-              https_read:
-                - description: http_read
-              https_write:
-                - description: http_write
+              - type: cli_credential
+                description:
+                  - WLC
+                  - CLI-1
+                  - NZ_GEN_CLI_ISE
+              - type: https_read
+                description:
+                  - NZ_GEN2_HTTPS_READ
+                  - http_read
+              - type: https_write
+                description:
+                  - NZ_GEN2_HTTPS_WRITE
 
     - name: Generate YAML Configuration with specific component assign credentials to site filters
       cisco.dnac.device_credential_playbook_config_generator:
@@ -78,9 +84,8 @@
           component_specific_filters:
             components_list: ["assign_credentials_to_site"]
             assign_credentials_to_site:
-              site_name:
-                - "Global/India/Assam"
-                - "Global/India/Haryana"
+              - "Global/India/Assam"
+              - "Global/India/Haryana"
 
     - name: Generate YAML Configuration with both global credential and assign credentials to site filters
       cisco.dnac.device_credential_playbook_config_generator:
@@ -100,13 +105,16 @@
           component_specific_filters:
             components_list: ["global_credential_details", "assign_credentials_to_site"]
             global_credential_details:
-              cli_credential:
-                - description: test
-              https_read:
-                - description: http_read
-              https_write:
-                - description: http_write
+              - type: cli_credential
+                description:
+                  - test
+                  - Router_CLI
+              - type: https_read
+                description:
+                  - http_read
+              - type: https_write
+                description:
+                  - http_write
             assign_credentials_to_site:
-              site_name:
-                - "Global/India/Assam"
-                - "Global/India/TamilNadu"
+              - "Global/India/Assam"
+              - "Global/India/TamilNadu"

--- a/plugins/modules/device_credential_playbook_config_generator.py
+++ b/plugins/modules/device_credential_playbook_config_generator.py
@@ -76,39 +76,65 @@ options:
     required: false
   config:
     description:
-    - A dictionary of filters for generating YAML playbook compatible with the `device_credential_workflow_manager`
-      module.
-    - Filters specify which components to include in the YAML configuration file.
-    - If "components_list" is specified, only those components are included, regardless of the filters.
-    - If config is not provided or is empty, all configurations for all global_credential_details and
-      assign_credentials_to_site will be generated.
-    - This is useful for complete brownfield infrastructure discovery and documentation.
+    - Top-level configuration block that controls the
+      scope and filtering of the generated YAML playbook
+      for the C(device_credential_workflow_manager) module.
+    - Contains C(component_specific_filters) to select
+      which credential components (global credentials,
+      site assignments) and which individual credentials
+      are included in the output.
+    - If C(config) is not provided or is empty, all global
+      credentials and all site credential assignments are
+      extracted (auto-discovery mode).
+    - This is useful for complete brownfield infrastructure
+      discovery and documentation.
     type: dict
     required: false
     suboptions:
       component_specific_filters:
         description:
-        - Filters to specify which components to include in the YAML configuration
-          file.
-        - If "components_list" is specified, only those components are included,
-          regardless of other filters.
-        - If filters for specific components (e.g., global_credential_details or assign_credentials_to_site) are provided
-          without explicitly including them in components_list, those components will be
-          automatically added to components_list.
-        - At least one of components_list or component filters must be provided.
+        - Container for all component-level and credential-level
+          filters that control what is included in the generated
+          YAML playbook.
+        - Holds C(components_list) to select which top-level
+          components to extract, and optional per-component
+          filters (C(global_credential_details),
+          C(assign_credentials_to_site)) for fine-grained
+          credential or site selection.
+        - If C(components_list) is specified, only the listed
+          components are included regardless of other filters.
+        - If per-component filters are provided without
+          explicitly including them in C(components_list),
+          those components are automatically added to
+          C(components_list).
+        - At least one of C(components_list) or per-component
+          filters must be provided.
         type: dict
         suboptions:
           components_list:
             description:
-            - List of credential components to include in YAML configuration.
-            - Valid values are 'global_credential_details' for global credentials
-              and 'assign_credentials_to_site' for site-specific assignments.
-            - If specified, only the listed components will be included in the generated YAML file.
-            - If not specified but component filters (global_credential_details or assign_credentials_to_site)
-              are provided, those components are automatically added to this list.
-            - If neither components_list nor any component filters are provided, an error will be raised.
+            - Selector that determines which top-level
+              credential components are extracted from
+              Catalyst Center and written to the YAML
+              playbook.
+            - Valid values are C(global_credential_details)
+              for global credentials and
+              C(assign_credentials_to_site) for site-specific
+              credential assignments.
+            - If specified, only the listed components are
+              included in the generated YAML file.
+            - If not specified but per-component filters
+              (C(global_credential_details) or
+              C(assign_credentials_to_site)) are provided,
+              those components are automatically added to
+              this list.
+            - If neither C(components_list) nor any
+              per-component filters are provided, an error
+              is raised.
             type: list
-            choices: ["global_credential_details", "assign_credentials_to_site"]
+            choices:
+              - global_credential_details
+              - assign_credentials_to_site
             elements: str
           global_credential_details:
             description:
@@ -118,8 +144,11 @@ options:
               Center credential description exactly (case-sensitive).
             - If C(description) is omitted (or empty) for a given C(type), all
               credentials of that type are extracted.
-            - Multiple entries with the same C(type) are allowed; their descriptions
-              are aggregated.
+            - When multiple entries with different C(type) values are provided,
+              each type is filtered independently (AND logic across types).
+            - If C(global_credential_details) is omitted entirely but
+              C(global_credential_details) is present in C(components_list),
+              all credentials of all types are extracted without filtering.
             - 'For example, [{"type": "cli_credential", "description": ["WLC", "Router_CLI"]},
               {"type": "https_read"}, {"type": "snmp_v3", "description": ["SNMPv3_Admin"]}]'
             type: list
@@ -142,23 +171,41 @@ options:
                   - snmp_v3
               description:
                 description:
-                - List of exact credential descriptions to extract for the given
-                  C(type).
-                - Each value must match a Catalyst Center credential description
-                  exactly (case-sensitive).
-                - If omitted or empty, all credentials of the specified C(type)
-                  are extracted.
+                - Human-readable labels assigned to credentials
+                  in Catalyst Center, used here as filter
+                  values to select specific credentials of the
+                  given C(type).
+                - Each value must match a Catalyst Center
+                  credential description exactly
+                  (case-sensitive).
+                - If omitted or empty, all credentials of the
+                  specified C(type) are extracted.
+                - When multiple entries share the same C(type),
+                  their C(description) lists are merged
+                  (union).
+                - 'For example: ["WLC", "Router_CLI"]'
                 type: list
                 elements: str
                 required: false
           assign_credentials_to_site:
             description:
-            - List of site hierarchical paths for credential assignment extraction.
-            - Extracts credential assignments for specified site hierarchical paths.
-            - Site names must be full hierarchical paths (case-sensitive).
-            - If not specified when component included in components_list, extracts
-              all site credential assignments.
-            - For example, ["Global/India/Assam", "Global/India/Haryana"]
+            - Site-level credential assignments that map global
+              credentials to specific sites in the Catalyst
+              Center site hierarchy.
+            - This parameter accepts a list of site
+              hierarchical path strings to control which site
+              assignments are extracted into the generated
+              YAML playbook.
+            - Each string must be a full hierarchical site
+              path starting from "Global"
+              (e.g., "Global/Region/Building").
+            - Site names are case-sensitive and must match
+              exact paths configured in Catalyst Center.
+            - If not specified when component is included in
+              C(components_list), extracts all site credential
+              assignments.
+            - 'For example:
+              ["Global/India/Assam", "Global/India/Haryana"]'
             type: list
             elements: str
             required: false
@@ -283,6 +330,34 @@ EXAMPLES = r"""
           - "Global/India/Assam"
           - "Global/India/Haryana"
 
+- name: Generate YAML with aggregated duplicate type filters
+  cisco.dnac.device_credential_playbook_config_generator:
+    dnac_host: "{{ dnac_host }}"
+    dnac_username: "{{ dnac_username }}"
+    dnac_password: "{{ dnac_password }}"
+    dnac_verify: "{{ dnac_verify }}"
+    dnac_port: "{{ dnac_port }}"
+    dnac_version: "{{ dnac_version }}"
+    dnac_debug: "{{ dnac_debug }}"
+    dnac_log: true
+    dnac_log_level: DEBUG
+    state: gathered
+    file_path: "device_credential_config.yml"
+    config:
+      component_specific_filters:
+        components_list:
+          - global_credential_details
+        global_credential_details:
+          # Two entries for same type — descriptions are merged
+          - type: cli_credential
+            description:
+              - WLC
+          - type: cli_credential
+            description:
+              - Router_CLI
+          # Omitting description extracts all of this type
+          - type: snmp_v3
+
 - name: Generate YAML Configuration with both global credential and assign credentials to site filters
   cisco.dnac.device_credential_playbook_config_generator:
     dnac_host: "{{ dnac_host }}"
@@ -307,7 +382,7 @@ EXAMPLES = r"""
           - type: https_read
             description:
               - http_read
-          - type: https_write
+          - type: https_write  # No description filter — extracts all
         assign_credentials_to_site:
           - "Global/India/Assam"
           - "Global/India/TamilNadu"
@@ -722,19 +797,19 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
 
         Returns:
             OrderedDict: Reverse mapping specification with credential type mappings:
-                        - cli_credential: List transformation with username, masked
-                        password/enable_password, description, and id fields
-                        - https_read: List transformation with username, masked password,
-                        port, description, and id fields
-                        - https_write: List transformation with username, masked password,
-                        port, description, and id fields
-                        - snmp_v2c_read: List transformation with masked read_community,
-                        description, and id fields
-                        - snmp_v2c_write: List transformation with write_community,
-                        description, and id fields
+                        - cli_credential: List transformation with description, username,
+                        masked password and enable_password fields
+                        - https_read: List transformation with description, username,
+                        masked password, and port fields
+                        - https_write: List transformation with description, username,
+                        masked password, and port fields
+                        - snmp_v2c_read: List transformation with description and
+                        masked read_community fields
+                        - snmp_v2c_write: List transformation with description and
+                        masked write_community fields
                         - snmp_v3: List transformation with auth_type, snmp_mode,
-                        privacy settings, username, masked auth_password,
-                        description, and id fields
+                        masked privacy_password, privacy_type, username,
+                        description, and masked auth_password fields
         """
         self.log(
             "Constructing reverse mapping specification for global credential details. "
@@ -899,7 +974,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "Reverse mapping specification constructed successfully with 6 credential "
             "type transformations. Specification includes field mappings for username, "
             "passwords (masked), ports, communities (masked for v2c read), auth settings "
-            "(masked for v3), and description/id fields for all credential types.",
+            "(masked for v3), and description fields for all credential types.",
             "DEBUG"
         )
 
@@ -927,19 +1002,20 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
 
         Returns:
             OrderedDict: Reverse mapping specification with site assignment mappings:
-                        - cli_credential: Dict transformation with description, username,
-                        and id fields extracted
-                        - https_read: Dict transformation with description, username,
-                        and id fields extracted
-                        - https_write: Dict transformation with description, username,
-                        and id fields extracted
-                        - snmp_v2c_read: Dict transformation with description and id
-                        fields extracted
-                        - snmp_v2c_write: Dict transformation with description and id
-                        fields extracted
-                        - snmp_v3: Dict transformation with description and id fields
+                        - cli_credential: Dict transformation with description and
+                        username fields extracted
+                        - https_read: Dict transformation with description and
+                        username fields extracted
+                        - https_write: Dict transformation with description and
+                        username fields extracted
+                        - snmp_v2c_read: Dict transformation with description
+                        field extracted
+                        - snmp_v2c_write: Dict transformation with description
+                        field extracted
+                        - snmp_v3: Dict transformation with description field
                         extracted
-                        - site_name: List of site names where credentials are assigned
+                        - site_name: List of site names where credentials are
+                        assigned
         """
         self.log(
             "Constructing reverse mapping specification for site credential "
@@ -1040,9 +1116,9 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         self.log(
             "Reverse mapping specification constructed successfully with 7 field "
             "mappings (6 credential types + site_name). Specification includes "
-            "transformations for CLI (description, username, id), HTTPS Read/Write "
-            "(description, username, id), SNMPv2c Read/Write (description, id), "
-            "SNMPv3 (description, id), and site_name list for location context.",
+            "transformations for CLI (description, username), HTTPS Read/Write "
+            "(description, username), SNMPv2c Read/Write (description), "
+            "SNMPv3 (description), and site_name list for location context.",
             "DEBUG"
         )
 
@@ -1291,6 +1367,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "WARNING",
                 )
                 continue
+
             f_type = entry.get("type")
             if f_type not in key_map:
                 self.log(
@@ -1301,6 +1378,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "WARNING",
                 )
                 continue
+
             desc = entry.get("description")
             existing = wanted_by_type.setdefault(f_type, set())
             if desc is None or (isinstance(desc, list) and len(desc) == 0):
@@ -1386,11 +1464,10 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                                 - api_function (str): SDK function name
                                     (e.g., 'get_device_credential_settings_for_a_site')
             filters (dict): Filter configuration containing:
-                        - component_specific_filters (dict, optional): Nested filters
-                            for site selection:
-                            - site_name (list): List of site hierarchical names to
-                            process (e.g., ['Global/India/Assam'])
-                        If component_specific_filters not provided or site_name empty,
+                        - component_specific_filters (list, optional): List of site
+                            hierarchical path strings for targeted extraction
+                            (e.g., ["Global/India/Assam", "Global/India/Haryana"]).
+                        If component_specific_filters is not provided or empty,
                         processes all sites from cached site mapping.
 
         Returns:
@@ -1612,6 +1689,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                     "WARNING"
                 )
                 continue
+
             self.log(
                 "Processing site {0}/{1} with site_id: {2}. Fetching credential sync "
                 "status using API family '{3}', function '{4}'.".format(
@@ -1716,6 +1794,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                         "DEBUG"
                     )
                     continue
+
                 self.log(
                     "Searching global credential cache for credential ID {0} in group "
                     "'{1}' for sync_key '{2}'.".format(cred_id, global_key, sync_key),

--- a/plugins/modules/device_credential_playbook_config_generator.py
+++ b/plugins/modules/device_credential_playbook_config_generator.py
@@ -112,138 +112,56 @@ options:
             elements: str
           global_credential_details:
             description:
-            - Filters for global device credential extraction.
-            - Extracts only credentials matching specified descriptions.
-            - Each credential type (cli_credential, https_read, https_write,
-              snmp_v2c_read, snmp_v2c_write, snmp_v3) can be filtered independently.
-            - Description values must match exactly as configured in Catalyst Center
-              (case-sensitive).
-            - If credential type not specified, all credentials of that type extracted.
-            type: dict
+            - List of credential filter entries for global device credential extraction.
+            - Each entry specifies a credential C(type) and an optional C(description).
+            - C(description) is a list of strings; each value must match a Catalyst
+              Center credential description exactly (case-sensitive).
+            - If C(description) is omitted (or empty) for a given C(type), all
+              credentials of that type are extracted.
+            - Multiple entries with the same C(type) are allowed; their descriptions
+              are aggregated.
+            - 'For example, [{"type": "cli_credential", "description": ["WLC", "Router_CLI"]},
+              {"type": "https_read"}, {"type": "snmp_v3", "description": ["SNMPv3_Admin"]}]'
+            type: list
+            elements: dict
+            required: false
             suboptions:
-              cli_credential:
+              type:
                 description:
-                - List of CLI credential descriptions to extract.
-                - Extracts CLI credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "WLC_CLI"}, {"description": "Router_CLI"}]'
-                type: list
-                elements: dict
-                required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of CLI credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
-              https_read:
+                - Credential type to filter.
+                - Must be one of cli_credential, https_read, https_write,
+                  snmp_v2c_read, snmp_v2c_write, snmp_v3.
+                type: str
+                required: true
+                choices:
+                  - cli_credential
+                  - https_read
+                  - https_write
+                  - snmp_v2c_read
+                  - snmp_v2c_write
+                  - snmp_v3
+              description:
                 description:
-                - List of HTTPS Read credential descriptions to extract.
-                - Extracts HTTPS Read credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "HTTPS_Read_Admin"}]'
+                - List of exact credential descriptions to extract for the given
+                  C(type).
+                - Each value must match a Catalyst Center credential description
+                  exactly (case-sensitive).
+                - If omitted or empty, all credentials of the specified C(type)
+                  are extracted.
                 type: list
-                elements: dict
+                elements: str
                 required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of HTTPS Read credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
-              https_write:
-                description:
-                - List of HTTPS Write credential descriptions to extract.
-                - Extracts HTTPS Write credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "HTTPS_Write_Admin"}]'
-                type: list
-                elements: dict
-                required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of HTTPS Write credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
-              snmp_v2c_read:
-                description:
-                - List of SNMPv2c Read credential descriptions to extract.
-                - Extracts SNMPv2c Read credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "SNMP_RO_Community"}]'
-                type: list
-                elements: dict
-                required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of SNMPv2c Read credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
-              snmp_v2c_write:
-                description:
-                - List of SNMPv2c Write credential descriptions to extract.
-                - Extracts SNMPv2c Write credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "SNMP_RW_Community"}]'
-                type: list
-                elements: dict
-                required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of SNMPv2c Write credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
-              snmp_v3:
-                description:
-                - List of SNMPv3 credential descriptions to extract.
-                - Extracts SNMPv3 credentials with matching description field.
-                - Each list item contains description key for filtering.
-                - 'For example: [{"description": "SNMPv3_Admin"}]'
-                type: list
-                elements: dict
-                required: false
-                suboptions:
-                  description:
-                    description:
-                    - Exact description of SNMPv3 credential to extract.
-                    - Must match Catalyst Center credential description exactly
-                      (case-sensitive).
-                    type: str
-                    required: true
           assign_credentials_to_site:
             description:
-            - Filters for site-specific credential assignment extraction.
+            - List of site hierarchical paths for credential assignment extraction.
             - Extracts credential assignments for specified site hierarchical paths.
             - Site names must be full hierarchical paths (case-sensitive).
             - If not specified when component included in components_list, extracts
               all site credential assignments.
-            type: dict
+            - For example, ["Global/India/Assam", "Global/India/Haryana"]
+            type: list
+            elements: str
             required: false
-            suboptions:
-              site_name:
-                description:
-                - List of site hierarchical paths to extract credential assignments.
-                - Site names must match exact hierarchical paths in Catalyst Center
-                  (case-sensitive).
-                - Extracts CLI, HTTPS Read/Write, SNMPv2c Read/Write, and SNMPv3
-                  credential assignments per site.
-                - For example, ["Global/India/Assam", "Global/India/Haryana"]
-                type: list
-                elements: str
-                required: false
 requirements:
 - dnacentersdk >= 2.10.10
 - python >= 3.9
@@ -330,12 +248,19 @@ EXAMPLES = r"""
       component_specific_filters:
         components_list: ["global_credential_details"]
         global_credential_details:
-          cli_credential:
-            - description: test
-          https_read:
-            - description: http_read
-          https_write:
-            - description: http_write
+          - type: cli_credential
+            description:
+              - WLC
+              - Router_CLI
+          - type: https_read
+            description:
+              - http_read
+          - type: https_write
+            description:
+              - http_write
+          - type: snmp_v2c_read
+          - type: snmp_v2c_write
+          - type: snmp_v3
 
 - name: Generate YAML Configuration with specific component assign credentials to site filters
   cisco.dnac.device_credential_playbook_config_generator:
@@ -355,9 +280,8 @@ EXAMPLES = r"""
       component_specific_filters:
         components_list: ["assign_credentials_to_site"]
         assign_credentials_to_site:
-          site_name:
-            - "Global/India/Assam"
-            - "Global/India/Haryana"
+          - "Global/India/Assam"
+          - "Global/India/Haryana"
 
 - name: Generate YAML Configuration with both global credential and assign credentials to site filters
   cisco.dnac.device_credential_playbook_config_generator:
@@ -377,16 +301,16 @@ EXAMPLES = r"""
       component_specific_filters:
         components_list: ["global_credential_details", "assign_credentials_to_site"]
         global_credential_details:
-          cli_credential:
-            - description: test
-          https_read:
-            - description: http_read
-          https_write:
-            - description: http_write
+          - type: cli_credential
+            description:
+              - WLC
+          - type: https_read
+            description:
+              - http_read
+          - type: https_write
         assign_credentials_to_site:
-          site_name:
-            - "Global/India/Assam"
-            - "Global/India/TamilNadu"
+          - "Global/India/Assam"
+          - "Global/India/TamilNadu"
 """
 
 RETURN = r"""
@@ -751,62 +675,29 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "network_elements": {
                 "global_credential_details": {
                     "filters": {
-                        "cli_credential": {
-                            "type": "list",
-                            "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
-
+                        "type": {
+                            "type": "str",
+                            "required": True,
+                            "choices": [
+                                "cli_credential",
+                                "https_read",
+                                "https_write",
+                                "snmp_v2c_read",
+                                "snmp_v2c_write",
+                                "snmp_v3",
+                            ],
                         },
-                        "https_read": {
+                        "description": {
                             "type": "list",
+                            "elements": "str",
                             "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
                         },
-                        "https_write": {
-                            "type": "list",
-                            "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
-                        },
-                        "snmp_v2c_read": {
-                            "type": "list",
-                            "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
-                        },
-                        "snmp_v2c_write": {
-                            "type": "list",
-                            "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
-
-                        },
-                        "snmp_v3": {
-                            "type": "list",
-                            "required": False,
-                            "elements": "dict",
-                            "options": {
-                                "description": {"type": "str"},
-                            }
-                        }
                     },
                     "reverse_mapping_function": self.global_credential_details_temp_spec,
                     "get_function_name": self.get_global_credential_details_configuration,
                 },
                 "assign_credentials_to_site": {
-                    "filters": ["site_name"],
+                    "filters": [],
                     "reverse_mapping_function": self.assign_credentials_to_site_temp_spec,
                     "api_function": "get_device_credential_settings_for_a_site",
                     "api_family": "network_settings",
@@ -916,8 +807,6 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                         # Sensitive fields masked
                         "password": mask("cli_credential", key, "password"),
                         "enable_password": mask("cli_credential", key, "enable_password"),
-                        # Non-sensitive fields passed through
-                        "id": key.get("id"),
                     }
                     for key in (detail.get("cliCredential") or [])
                 ],
@@ -935,7 +824,6 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                         "password": mask("https_read", key, "password"),
                         # Non-sensitive fields passed through
                         "port": key.get("port"),
-                        "id": key.get("id"),
                     }
                     for key in (detail.get("httpsRead") or [])
                 ],
@@ -953,7 +841,6 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                         "password": mask("https_write", key, "password"),
                         # Non-sensitive fields passed through
                         "port": key.get("port"),
-                        "id": key.get("id"),
                     }
                     for key in (detail.get("httpsWrite") or [])
                 ],
@@ -966,7 +853,6 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "transform": lambda detail: [
                     {
                         # Non-sensitive fields passed through
-                        "id": key.get("id"),
                         "description": key.get("description"),
                         # Sensitive field masked
                         "read_community": mask("snmp_v2c_read", key, "read_community"),
@@ -978,11 +864,15 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "type": "list",
                 "elements": "dict",
                 "source_key": "snmpV2cWrite",
-                "options": OrderedDict({
-                    "id": {"type": "str", "source_key": "id"},
-                    "description": {"type": "str", "source_key": "description"},
-                    "write_community": {"type": "str", "source_key": "writeCommunity"},
-                }),
+                "special_handling": True,
+                "transform": lambda detail: [
+                    {
+                        "description": key.get("description"),
+                        # Sensitive field masked
+                        "write_community": mask("snmp_v2c_write", key, "write_community"),
+                    }
+                    for key in (detail.get("snmpV2cWrite") or [])
+                ],
             },
             "snmp_v3": {
                 "type": "list",
@@ -992,10 +882,9 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "transform": lambda detail: [
                     {
                         # Non-sensitive fields passed through
-                        "id": key.get("id"),
                         "auth_type": key.get("authType"),
                         "snmp_mode": key.get("snmpMode"),
-                        "privacy_password": key.get("privacyPassword"),
+                        "privacy_password": mask("snmp_v3", key, "privacy_password"),
                         "privacy_type": key.get("privacyType"),
                         "username": key.get("username"),
                         "description": key.get("description"),
@@ -1109,37 +998,37 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "type": "dict",
                 "source_key": "cliCredential",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("cliCredential"), ["description", "username", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("cliCredential"), ["description", "username"]),
             },
             "https_read": {
                 "type": "dict",
                 "source_key": "httpsRead",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("httpsRead"), ["description", "username", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("httpsRead"), ["description", "username"]),
             },
             "https_write": {
                 "type": "dict",
                 "source_key": "httpsWrite",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("httpsWrite"), ["description", "username", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("httpsWrite"), ["description", "username"]),
             },
             "snmp_v2c_read": {
                 "type": "dict",
                 "source_key": "snmpV2cRead",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("snmpV2cRead"), ["description", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("snmpV2cRead"), ["description"]),
             },
             "snmp_v2c_write": {
                 "type": "dict",
                 "source_key": "snmpV2cWrite",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("snmpV2cWrite"), ["description", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("snmpV2cWrite"), ["description"]),
             },
             "snmp_v3": {
                 "type": "dict",
                 "source_key": "snmpV3",
                 "special_handling": True,
-                "transform": lambda detail: pick_fields(detail.get("snmpV3"), ["description", "id"]),
+                "transform": lambda detail: pick_fields(detail.get("snmpV3"), ["description"]),
             },
             "site_name": {
                 "type": "list",
@@ -1341,164 +1230,140 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
 
     def filter_credentials(self, source, filters):
         """
-        Filters global credential groups by matching description fields.
+        Filters global credential groups based on a list of type/description entries.
 
-        This function applies component-specific filters to global credential data by
-        matching credential descriptions against requested filter criteria, extracting
-        only credentials with matching descriptions from each credential type group
-        (CLI, HTTPS Read/Write, SNMPv2c Read/Write, SNMPv3), and constructing a filtered
-        credential dictionary containing only matched items for targeted credential
-        selection in YAML generation workflow.
+        Accepts a list of filter entries where each entry specifies a credential
+        ``type`` (required) and an optional ``description``. ``description`` is a
+        list of strings; each value must match a credential's description exactly
+        (case-sensitive). If ``description`` is omitted (or empty) for a given
+        ``type``, all credentials of that type are included. Multiple entries
+        with the same ``type`` are aggregated.
 
         Args:
-            source (dict): Global credentials dictionary from Catalyst Center containing
-                        credential groups with camelCase keys (e.g., cliCredential,
-                        httpsRead, httpsWrite, snmpV2cRead, snmpV2cWrite, snmpV3).
-                        Each group contains list of credential objects with description,
-                        username, id, and sensitive credential fields.
-            filters (dict): Component-specific filter dictionary with snake_case keys
-                        (e.g., cli_credential, https_read) containing lists of
-                        filter objects. Each filter object specifies description
-                        field to match (e.g., [{"description": "WLC"}]).
+            source (dict): Global credentials dictionary from Catalyst Center
+                containing credential groups with camelCase keys (e.g.,
+                cliCredential, httpsRead, httpsWrite, snmpV2cRead, snmpV2cWrite,
+                snmpV3).
+            filters (list): List of filter dicts. Each item has a required ``type``
+                key (snake_case credential type) and an optional ``description``
+                list of strings.
 
         Returns:
-            dict: Filtered credentials dictionary with camelCase keys containing only
-                credential objects matching filter descriptions. Empty dictionary if
-                no matches found or source/filters invalid. Preserves original API
-                response structure with matched items only.
+            dict: Filtered credentials dictionary with camelCase keys containing
+                only matched credential objects. Empty dict if nothing matched.
         """
         self.log(
-            "Starting credential filtering operation with {0} source credential "
-            "groups and {1} filter criteria. Filtering extracts credentials matching "
-            "description fields from each credential type group.".format(
+            "Starting credential filtering with {0} source group(s) and {1} filter "
+            "entry/entries.".format(
                 len(source) if isinstance(source, dict) else 0,
-                len(filters) if isinstance(filters, dict) else 0
+                len(filters) if isinstance(filters, list) else 0,
             ),
-            "DEBUG"
-        )
-
-        self.log(
-            "Source credential groups available: {0}. Filters provided for credential "
-            "types: {1}.".format(
-                list(source.keys()) if isinstance(source, dict) else [],
-                list(filters.keys()) if isinstance(filters, dict) else []
-            ),
-            "DEBUG"
-        )
-
-        self.log(
-            "Initializing filter key mapping from snake_case filter keys to camelCase "
-            "API response keys for credential group matching. Mapping enables "
-            "consistent filter application across 6 credential types.",
-            "DEBUG"
+            "DEBUG",
         )
 
         key_map = {
-            'cli_credential': 'cliCredential',
-            'https_read': 'httpsRead',
-            'https_write': 'httpsWrite',
-            'snmp_v2c_read': 'snmpV2cRead',
-            'snmp_v2c_write': 'snmpV2cWrite',
-            'snmp_v3': 'snmpV3',
+            "cli_credential": "cliCredential",
+            "https_read": "httpsRead",
+            "https_write": "httpsWrite",
+            "snmp_v2c_read": "snmpV2cRead",
+            "snmp_v2c_write": "snmpV2cWrite",
+            "snmp_v3": "snmpV3",
         }
+
+        if not isinstance(filters, list):
+            self.log(
+                "Expected filters to be a list, got {0}. Returning empty result.".format(
+                    type(filters).__name__
+                ),
+                "WARNING",
+            )
+            return {}
+
+        # Group filter entries by credential type. None as a member means
+        # "include all credentials of that type" (no description constraint).
+        wanted_by_type = {}
+        for entry_index, entry in enumerate(filters, start=1):
+            if not isinstance(entry, dict):
+                self.log(
+                    "Filter entry {0} is not a dict ({1}); skipping.".format(
+                        entry_index, type(entry).__name__
+                    ),
+                    "WARNING",
+                )
+                continue
+            f_type = entry.get("type")
+            if f_type not in key_map:
+                self.log(
+                    "Filter entry {0} has invalid or missing 'type': {1}. "
+                    "Valid types: {2}. Skipping.".format(
+                        entry_index, f_type, list(key_map.keys())
+                    ),
+                    "WARNING",
+                )
+                continue
+            desc = entry.get("description")
+            existing = wanted_by_type.setdefault(f_type, set())
+            if desc is None or (isinstance(desc, list) and len(desc) == 0):
+                # No description constraint -> include all credentials of this type
+                existing.add(None)
+            elif isinstance(desc, list):
+                for d in desc:
+                    if d is None:
+                        existing.add(None)
+                    else:
+                        existing.add(d)
+            else:
+                self.log(
+                    "Filter entry {0}: 'description' must be a list of strings, "
+                    "got {1}. Skipping.".format(
+                        entry_index, type(desc).__name__
+                    ),
+                    "WARNING",
+                )
+                continue
+
         result = {}
-        processed_filters = 0
         matched_credentials = 0
-
-        self.log(
-            "Starting iteration through {0} filter entries to extract matching "
-            "credentials from source groups. Each filter specifies description "
-            "criteria for credential selection.".format(len(filters)),
-            "DEBUG"
-        )
-        for filter_index, (f_key, wanted_list) in enumerate(filters.items(), start=1):
-            self.log(
-                "Processing filter {0}/{1} for credential type '{2}' with {3} "
-                "description filter(s). Resolving API key and extracting wanted "
-                "descriptions for matching.".format(
-                    filter_index, len(filters), f_key, len(wanted_list)
-                ),
-                "DEBUG"
-            )
-            src_key = key_map.get(f_key)
-            if not src_key:
+        for f_type, descriptions in wanted_by_type.items():
+            src_key = key_map[f_type]
+            src_items = source.get(src_key) or []
+            if None in descriptions:
+                # No description constraint -> include all credentials of this type
+                matched = list(src_items)
                 self.log(
-                    "Filter key '{0}' not found in key mapping. Skipping unsupported "
-                    "credential type filter. Valid filter keys: {1}".format(
-                        f_key, list(key_map.keys())
-                    ),
-                    "WARNING"
+                    "Type '{0}': no description filter, including all {1} "
+                    "credential(s).".format(f_type, len(matched)),
+                    "DEBUG",
                 )
-                continue
-
-            if src_key not in source:
+            else:
+                matched = [
+                    item for item in src_items
+                    if item.get("description") in descriptions
+                ]
                 self.log(
-                    "Credential group '{0}' (mapped from filter key '{1}') not found "
-                    "in source credentials. Skipping filter for this group. Available "
-                    "source groups: {2}".format(
-                        src_key, f_key, list(source.keys())
+                    "Type '{0}': matched {1}/{2} credential(s) for descriptions "
+                    "{3}.".format(
+                        f_type, len(matched), len(src_items), descriptions
                     ),
-                    "DEBUG"
+                    "DEBUG",
                 )
-                continue
 
-            self.log(
-                "Extracting wanted descriptions from {0} filter objects for credential "
-                "type '{1}'. Building description set for efficient matching against "
-                "source credentials.".format(len(wanted_list), f_key),
-                "DEBUG"
-            )
-            wanted_desc = {item.get('description') for item in wanted_list if 'description' in item}
-            self.log(
-                "Extracted {0} unique description(s) from filter criteria: {1}. "
-                "Matching against {2} credential(s) in source group '{3}'.".format(
-                    len(wanted_desc), wanted_desc, len(source[src_key]), src_key
-                ),
-                "DEBUG"
-            )
-
-            self.log(
-                "Filtering credential group '{0}' with {1} source credential(s) "
-                "against {2} wanted description(s). Extracting credentials with "
-                "matching description fields.".format(
-                    src_key, len(source[src_key]), len(wanted_desc)
-                ),
-                "DEBUG"
-            )
-            matched = [item for item in source[src_key] if item.get('description') in wanted_desc]
             if matched:
                 result[src_key] = matched
                 matched_credentials += len(matched)
-                processed_filters += 1
-
-                self.log(
-                    "Filter {0}/{1} for '{2}' matched {3} credential(s) from {4} "
-                    "source credential(s). Matched credentials added to result "
-                    "dictionary under key '{5}'.".format(
-                        filter_index, len(filters), f_key, len(matched),
-                        len(source[src_key]), src_key
-                    ),
-                    "DEBUG"
-                )
             else:
                 self.log(
-                    "Filter {0}/{1} for '{2}' matched 0 credentials from {3} source "
-                    "credential(s). No credentials found with descriptions matching: "
-                    "{4}. Group '{5}' will not be included in result.".format(
-                        filter_index, len(filters), f_key, len(source[src_key]),
-                        wanted_desc, src_key
-                    ),
-                    "WARNING"
+                    "Type '{0}': no credentials matched; group not included in "
+                    "result.".format(f_type),
+                    "WARNING",
                 )
 
         self.log(
-            "Credential filtering completed successfully. Processed {0}/{1} filter "
-            "criteria, matched {2} total credential(s) across {3} credential group(s). "
-            "Result contains groups: {4}".format(
-                processed_filters, len(filters), matched_credentials,
-                len(result), list(result.keys())
+            "Credential filtering completed. Matched {0} credential(s) across "
+            "{1} group(s): {2}".format(
+                matched_credentials, len(result), list(result.keys())
             ),
-            "INFO"
+            "INFO",
         )
         return result
 
@@ -1606,7 +1471,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
 
         site_names = []
         if component_specific_filters:
-            site_names = component_specific_filters.get("site_name", []) or []
+            site_names = list(component_specific_filters) if isinstance(component_specific_filters, list) else []
             self.log(
                 "Using filtered site names from component_specific_filters: {0}. "
                 "Will process {1} specified site(s).".format(site_names, len(site_names)),
@@ -1897,6 +1762,18 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "DEBUG"
             )
 
+            # Skip sites with no credentials assigned (only siteName remaining).
+            credential_keys = [k for k in raw_assign.keys() if k != "siteName"]
+            if not credential_keys:
+                self.log(
+                    "Site '{0}' (site_id: {1}) has no credentials assigned. "
+                    "Skipping this site in generated playbook.".format(
+                        self.site_id_name_dict.get(site_id, "UNKNOWN SITE"), site_id
+                    ),
+                    "INFO",
+                )
+                continue
+
             self.log(
                 "Retrieving reverse mapping specification for site credential "
                 "assignment transformation. Specification extracts non-sensitive fields "
@@ -1990,342 +1867,6 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "Generated custom variable name: {0}".format(custom_variable_name), "DEBUG"
         )
         return custom_variable_name
-
-    def yaml_config_generator(self, yaml_config_generator):
-        """
-        Generates a YAML configuration file based on the provided parameters.
-        This function retrieves network element details using component-specific filters, processes the data,
-        and writes the YAML content to a specified file. It dynamically handles multiple network elements and their respective filters.
-
-        Args:
-            yaml_config_generator (dict): Contains component_specific_filters and optionally generate_all_configurations flag.
-                file_path and file_mode are now taken from self.params.
-
-        Returns:
-            self: The current instance with the operation result and message updated.
-        """
-
-        self.log(
-            "Starting YAML configuration generation workflow for device credential "
-            "brownfield playbook. Workflow includes file path determination, "
-            "auto-discovery mode processing, component iteration with filters, and "
-            "YAML file writing with header comments.",
-            "DEBUG"
-        )
-
-        self.log(
-            "YAML config generator parameters received: {0}. Extracting "
-            "generate_all_configurations flag, file_path, and filter configurations.".format(
-                yaml_config_generator
-            ),
-            "DEBUG"
-        )
-
-        # Check if generate_all_configurations mode is enabled
-        generate_all = yaml_config_generator.get("generate_all_configurations", False)
-        if generate_all:
-            self.log(
-                "Auto-discovery mode enabled (generate_all_configurations=True). Will "
-                "process all device credentials and all supported components without "
-                "filter restrictions for complete brownfield inventory.",
-                "INFO"
-            )
-        else:
-            self.log(
-                "Targeted extraction mode (generate_all_configurations=False). Will "
-                "apply provided filters for selective component and credential retrieval.",
-                "DEBUG"
-            )
-
-        self.log(
-            "Determining output file path for YAML configuration. Checking for "
-            "user-provided file_path parameter or generating default timestamped "
-            "filename.",
-            "DEBUG"
-        )
-        file_path = self.params.get("file_path")
-        if not file_path:
-            self.log(
-                "No file_path provided in configuration. Generating default filename "
-                "with pattern device_credential_playbook_config_<YYYY-MM-DD_HH-MM-SS>.yml in "
-                "current working directory.",
-                "DEBUG"
-            )
-            file_path = self.generate_filename()
-            self.log(
-                "Default filename generated: {0}. File will be created in current "
-                "working directory.".format(file_path),
-                "DEBUG"
-            )
-        else:
-            self.log(
-                "Using user-provided file_path: {0}. File will be created at "
-                "specified location with directory creation if needed.".format(file_path),
-                "DEBUG"
-            )
-
-        self.log(
-            "YAML configuration file path determined: {0}. Path will be used for "
-            "write_dict_to_yaml() operation.".format(file_path),
-            "INFO"
-        )
-        file_mode = self.params.get("file_mode", "overwrite")
-
-        self.log(
-            "YAML configuration file path determined: {0}, file_mode: {1}".format(file_path, file_mode),
-            "DEBUG"
-        )
-
-        self.log(
-            "Initializing filter dictionaries from yaml_config_generator parameters. "
-            "Filters determine which components and credentials to extract from "
-            "Catalyst Center.",
-            "DEBUG"
-        )
-        if generate_all:
-            # In generate_all_configurations mode, override any provided filters to ensure we get ALL configurations
-            self.log(
-                "Auto-discovery mode: Overriding any provided filters to ensure "
-                "complete credential and component extraction without restrictions. "
-                "All component_specific_filters will be ignored.",
-                "INFO"
-            )
-
-            # Set empty filters to retrieve everything
-            component_specific_filters = {}
-        else:
-            # Use provided filters or default to empty
-            self.log(
-                "Normal mode: Using provided component_specific_filters from input",
-                "DEBUG",
-            )
-            component_specific_filters = yaml_config_generator.get("component_specific_filters") or {}
-            self.log(
-                f"Component specific filters initialized: {self.pprint(component_specific_filters)}",
-                "DEBUG",
-            )
-
-        self.log(
-            "Retrieving supported network elements schema from module_schema. Schema "
-            "defines available components (global_credential_details, "
-            "assign_credentials_to_site) with their retrieval functions and filter "
-            "specifications.",
-            "DEBUG"
-        )
-        module_supported_network_elements = self.module_schema.get("network_elements", {})
-
-        self.log(
-            "Module supports {0} network element component(s): {1}. Components define "
-            "available credential types and site assignment configurations.".format(
-                len(module_supported_network_elements),
-                list(module_supported_network_elements.keys())
-            ),
-            "DEBUG"
-        )
-
-        self.log(
-            "Determining components list for processing. Extracting components_list "
-            "from component_specific_filters or defaulting to all supported components "
-            "from module schema.",
-            "DEBUG"
-        )
-        components_list = component_specific_filters.get(
-            "components_list", list(module_supported_network_elements.keys())
-        )
-
-        # If components_list is empty, default to all supported components
-        if not components_list:
-            self.log(
-                "No components specified in components_list. Defaulting to all "
-                "supported components for complete credential extraction: {0}".format(
-                    list(module_supported_network_elements.keys())
-                ),
-                "DEBUG"
-            )
-            components_list = list(module_supported_network_elements.keys())
-        else:
-            self.log(
-                "Components list extracted from filters: {0}. Will process {1} "
-                "component(s) for targeted credential retrieval.".format(
-                    components_list, len(components_list)
-                ),
-                "DEBUG"
-            )
-
-        self.log(
-            "Components to process: {0}. Starting iteration through components for "
-            "credential retrieval and configuration aggregation.".format(components_list),
-            "INFO"
-        )
-
-        self.log(
-            "Initializing final configuration list for aggregating component data. "
-            "List will contain retrieved configurations from all processed components "
-            "ready for YAML serialization.",
-            "DEBUG"
-        )
-
-        final_config_list = []
-        processed_count = 0
-        skipped_count = 0
-
-        self.log(
-            "Starting component iteration loop. Processing {0} component(s) with "
-            "retrieval functions, filter application, and data aggregation for each.".format(
-                len(components_list)
-            ),
-            "DEBUG"
-        )
-        for component_index, component in enumerate(components_list, start=1):
-            self.log(
-                "Processing component {0}/{1}: '{2}'. Checking module schema for "
-                "component support and retrieval function availability.".format(
-                    component_index, len(components_list), component
-                ),
-                "DEBUG"
-            )
-            network_element = module_supported_network_elements.get(component)
-            if not network_element:
-                self.log(
-                    "Component {0} not supported by module, skipping processing".format(component),
-                    "WARNING",
-                )
-                skipped_count += 1
-                continue
-
-            filters = {
-                "component_specific_filters": component_specific_filters.get(component, [])
-            }
-
-            self.log(
-                "Extracting retrieval function for component '{0}' from network element "
-                "schema. Function will execute API calls and data transformation for "
-                "this component.".format(component),
-                "DEBUG"
-            )
-            operation_func = network_element.get("get_function_name")
-            if not callable(operation_func):
-                self.log(
-                    "No retrieval function defined for component: {0}".format(component),
-                    "ERROR"
-                )
-                skipped_count += 1
-                continue
-
-            component_data = operation_func(network_element, filters)
-            # Validate retrieval success
-            if not component_data:
-                self.log(
-                    "No data retrieved for component: {0}".format(component),
-                    "DEBUG"
-                )
-                continue
-
-            self.log(
-                "Details retrieved for {0}: {1}".format(component, component_data), "DEBUG"
-            )
-            processed_count += 1
-
-            if isinstance(component_data, list):
-                final_config_list.extend(component_data)
-                self.log(
-                    "Component '{0}' returned list with {1} item(s). Extended final "
-                    "configuration list. Total configurations: {2}".format(
-                        component, len(component_data), len(final_config_list)
-                    ),
-                    "DEBUG"
-                )
-            else:
-                final_config_list.append(component_data)
-                self.log(
-                    "Component '{0}' returned single dictionary. Appended to final "
-                    "configuration list. Total configurations: {1}".format(
-                        component, len(final_config_list)
-                    ),
-                    "DEBUG"
-                )
-
-        self.log(
-            "Component iteration completed. Processed {0}/{1} component(s), skipped "
-            "{2} component(s). Final configuration list contains {3} item(s) for YAML "
-            "generation.".format(
-                processed_count, len(components_list), skipped_count,
-                len(final_config_list)
-            ),
-            "INFO"
-        )
-        if not final_config_list:
-            self.log(
-                "No configurations retrieved after processing {0} component(s). "
-                "Processed: {1}, Skipped: {2}. All filters may have excluded available "
-                "credentials or no credentials exist in Catalyst Center for requested "
-                "components: {3}".format(
-                    len(components_list), processed_count, skipped_count, components_list
-                ),
-                "WARNING"
-            )
-            self.msg = {
-                "status": "ok",
-                "message": (
-                    "No configurations found for module '{0}'. Verify filters and component availability. "
-                    "Components attempted: {1}".format(self.module_name, components_list)
-                ),
-                "components_attempted": len(components_list),
-                "components_processed": processed_count,
-                "components_skipped": skipped_count
-            }
-            self.set_operation_result("ok", False, self.msg, "INFO")
-            return self
-
-        yaml_config_dict = {"config": final_config_list}
-        self.log(
-            "Final YAML configuration dictionary created successfully. Dictionary "
-            "structure: {0}. Proceeding with write_dict_to_yaml() operation.".format(
-                self.pprint(yaml_config_dict)
-            ),
-            "DEBUG"
-        )
-
-        self.log(
-            "Writing YAML configuration dictionary to file path: {0}. Using "
-            "OrderedDumper for consistent key ordering and formatting.".format(file_path),
-            "DEBUG"
-        )
-
-        if self.write_dict_to_yaml(yaml_config_dict, file_path, file_mode, dumper=OrderedDumper):
-            self.log(
-                "YAML file write operation succeeded. File created at: {0}. File "
-                "contains {1} configuration(s) with header comments and formatted "
-                "structure.".format(file_path, len(final_config_list)),
-                "INFO"
-            )
-            self.msg = {
-                "status": "success",
-                "message": "YAML configuration file generated successfully for module '{0}'".format(
-                    self.module_name
-                ),
-                "file_path": file_path,
-                "components_processed": processed_count,
-                "components_skipped": skipped_count,
-                "configurations_count": len(final_config_list)
-            }
-            self.set_operation_result("success", True, self.msg, "INFO")
-
-            self.log(
-                "YAML configuration generation completed. File: {0}, Components: {1}/{2}, Configs: {3}".format(
-                    file_path, processed_count, len(components_list), len(final_config_list)
-                ),
-                "INFO"
-            )
-        else:
-            self.msg = {
-                "YAML config generation Task failed for module '{0}'.".format(
-                    self.module_name
-                ): {"file_path": file_path}
-            }
-            self.set_operation_result("failed", True, self.msg, "ERROR")
-
-        return self
 
     def get_diff_gathered(self):
         """

--- a/plugins/modules/sda_host_port_onboarding_playbook_config_generator.py
+++ b/plugins/modules/sda_host_port_onboarding_playbook_config_generator.py
@@ -962,21 +962,31 @@ class SdaHostPortOnboardingPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
         return {
             "network_elements": {
                 "port_assignments": {
-                    "filters": ["fabric_site_name_hierarchy"],
+                    "filters": {
+                        "fabric_site_name_hierarchy": {"type": "str"},
+                        "device_ips": {"type": "list", "elements": "str"},
+                        "serial_numbers": {"type": "list", "elements": "str"},
+                        "hostnames": {"type": "list", "elements": "str"},
+                    },
                     "reverse_mapping_function": self.port_assignments_temp_spec,
                     "api_function": "get_port_assignments",
                     "api_family": "sda",
                     "get_function_name": self.get_port_assignments_configuration,
                 },
                 "port_channels": {
-                    "filters": ["fabric_site_name_hierarchy"],
+                    "filters": {
+                        "fabric_site_name_hierarchy": {"type": "str"},
+                        "device_ips": {"type": "list", "elements": "str"},
+                        "serial_numbers": {"type": "list", "elements": "str"},
+                        "hostnames": {"type": "list", "elements": "str"},
+                    },
                     "reverse_mapping_function": self.port_channels_temp_spec,
                     "api_function": "get_port_channels",
                     "api_family": "sda",
                     "get_function_name": self.get_port_channels_configuration,
                 },
                 "wireless_ssids": {
-                    "filters": ["fabric_site_name_hierarchy"],
+                    "filters": {"fabric_site_name_hierarchy": {"type": "str"}},
                     "reverse_mapping_function": self.wireless_ssids_temp_spec,
                     "api_function": "retrieve_the_vlans_and_ssids_mapped_to_the_vlan_within_a_fabric_site",
                     "api_family": "fabric_wireless",

--- a/tests/unit/modules/dnac/fixtures/device_credential_playbook_config_generator.json
+++ b/tests/unit/modules/dnac/fixtures/device_credential_playbook_config_generator.json
@@ -2,22 +2,20 @@
   "playbook_config_global_credentials_filtered": {
     "component_specific_filters": {
       "components_list": ["global_credential_details"],
-      "global_credential_details": {
-        "cli_credential": [ {"description": "WLC"}, {"description": "test"} ],
-        "https_read": [ {"description": "http_read"} ],
-        "https_write": [ {"description": "http_write"} ],
-        "snmp_v2c_read": [ {"description": "SNMPv2c Read Assam"} ],
-        "snmp_v2c_write": [ {"description": "SNMPv2c Write Haryana"} ],
-        "snmp_v3": [ {"description": "SNMPv3-credentials"} ]
-      }
+      "global_credential_details": [
+        {"type": "cli_credential", "description": ["WLC", "test"]},
+        {"type": "https_read", "description": ["http_read"]},
+        {"type": "https_write", "description": ["http_write"]},
+        {"type": "snmp_v2c_read", "description": ["SNMPv2c Read Assam"]},
+        {"type": "snmp_v2c_write", "description": ["SNMPv2c Write Haryana"]},
+        {"type": "snmp_v3", "description": ["SNMPv3-credentials"]}
+      ]
     }
   },
   "playbook_config_assign_credentials_to_site_filtered": {
     "component_specific_filters": {
       "components_list": ["assign_credentials_to_site"],
-      "assign_credentials_to_site": {
-        "site_name": ["Global/Fabric_Test"]
-      }
+      "assign_credentials_to_site": ["Global/Fabric_Test"]
     }
   },
   "playbook_config_no_file_path": {
@@ -156,33 +154,35 @@
   },
   "get_device_credential_settings_for_a_site_response": {
     "response": {
-      "cliCredential": {
-        "username": "nedmin",
-        "description": "WLC",
-        "id": "edd9f2c2-4876-4b73-8627-c5bf839564ee"
+      "cliCredentialsId": {
+        "credentialsId": "edd9f2c2-4876-4b73-8627-c5bf839564ee",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       },
-      "httpRead": {
-        "username": "wlcaccess",
-        "description": "http_read",
-        "id": "eedbeec9-9134-4d50-a482-3523649cd6f6"
+      "httpReadCredentialsId": {
+        "credentialsId": "eedbeec9-9134-4d50-a482-3523649cd6f6",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       },
-      "httpWrite": {
-        "username": "wlcaccess",
-        "description": "http_write",
-        "id": "a68a3bf4-c8bc-4b55-9273-5ebd52d416de"
+      "httpWriteCredentialsId": {
+        "credentialsId": "a68a3bf4-c8bc-4b55-9273-5ebd52d416de",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       },
-      "snmpV2cRead": {
-        "description": "SNMPv2c Read Assam",
-        "id": "30867aac-abc2-49a1-ab16-49c4d3f0bdf8"
+      "snmpv2cReadCredentialsId": {
+        "credentialsId": "30867aac-abc2-49a1-ab16-49c4d3f0bdf8",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       },
-      "snmpV2cWrite": {
-        "description": "SNMPv2c Write Haryana",
-        "id": "b1b2c3d4-1111-2222-3333-444455556666"
+      "snmpv2cWriteCredentialsId": {
+        "credentialsId": "b1b2c3d4-1111-2222-3333-444455556666",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       },
-      "snmpV3": {
-        "username": "v3Public",
-        "description": "SNMPv3-credentials",
-        "id": "803411a0-2371-4bb1-a7fb-65be95c707d6"
+      "snmpv3CredentialsId": {
+        "credentialsId": "803411a0-2371-4bb1-a7fb-65be95c707d6",
+        "inheritedSiteId": "1ae4d125-ef5a-4965-8ab2-c4de99f2858b",
+        "inheritedSiteName": "Global/Fabric_Test"
       }
     },
     "version": "1.0"


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Simplified the playbook structure of device_credential_playbook_config_generator module
Changed component-specific filter from dict to list of dict.
Added new parameter "type" to specify the type of credentials for filtering.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

