### PR TITLE
Wireless Profile CG - Reopened bug fixed

### DIFF
--- a/plugins/modules/network_profile_wireless_playbook_config_generator.py
+++ b/plugins/modules/network_profile_wireless_playbook_config_generator.py
@@ -2424,6 +2424,7 @@ class NetworkProfileWirelessPlaybookGenerator(NetworkProfileFunctions, BrownFiel
                 "status and informational message about filter validation.",
                 "INFO"
             )
+            return self
 
         self.log(
             "Constructing final YAML configuration dictionary with 'config' key. "


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Summary:
Bug raised for if data is not available for the filter need to show the output message instead of empty config. 

Steps to Reproduce:
Give the global filter value not available in catalyst center.

Observed Behavior:
What is currently happening, including error messages or symptoms.

Expected Behavior:
What should happen under normal conditions.

Root Cause Analysis:
Technical explanation of the underlying cause, if known.

Workaround:
Any temporary solutions or mitigations available.

Fix Details:
Description of the fix or code changes made.

Impact:
Information on the scope and severity of the issue.

Additional Information:
Logs, configuration snippets, environment details, or references to related bugs.

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [x] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

