### PR TITLE
Return None in case of invalid syntax

### DIFF
--- a/plugins/modules/device_credential_playbook_config_generator.py
+++ b/plugins/modules/device_credential_playbook_config_generator.py
@@ -1310,6 +1310,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "WARNING"
             )
             return None
+
         return {"global_credential_details": mapped}
 
     def filter_credentials(self, source, filters):

--- a/plugins/modules/device_credential_playbook_config_generator.py
+++ b/plugins/modules/device_credential_playbook_config_generator.py
@@ -1302,6 +1302,14 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
             "DEBUG"
         )
         mapped = mapped_list[0] if mapped_list else {}
+        if not mapped:
+            self.log(
+                "No credentials mapped after transformation. Final mapped structure is "
+                "empty. This may indicate invalid filters or missing credential data. "
+                "Returning empty credential details.",
+                "WARNING"
+            )
+            return None
         return {"global_credential_details": mapped}
 
     def filter_credentials(self, source, filters):
@@ -1587,7 +1595,7 @@ class DeviceCredentialPlaybookConfigGenerator(DnacBase, BrownFieldHelper):
                 "assignment dictionary.".format(site_names),
                 "WARNING"
             )
-            return {"assign_credentials_to_site": {}}
+            return None
 
         self.log(
             "Initializing credential ID to group mapping for credential matching. "


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Summary:
The device_credential_playbook_config_generator module creates YAML files even when the filters match nothing. This contradicts the documented behavior, which says no file should be created and the module should return a "No configurations found" message.

Made changes to return None in case of invalid filters

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

